### PR TITLE
ci(test): fix cache paths

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            _neovim
-            lua_modules
+            nvim-*/
+            .luarocks/
           key: ${{ runner.os }}-${{ matrix.nvim_version }}-${{ hashFiles('todays-date') }}
       - uses: notomo/action-setup-nvim-lua@v1
       - run: luarocks --lua-version=5.1 install fennel


### PR DESCRIPTION
luarocks installation path is set to `.local/.luarocks/` by `notomo/action-setup-nvim-lua@v1` 