### PR TITLE
perf(autocmd): set `pattern` to `nil` when it's default `*`

### DIFF
--- a/fnl/nvim-laurel/macros/init.fnl
+++ b/fnl/nvim-laurel/macros/init.fnl
@@ -626,6 +626,9 @@
                              (: :match "%*")))
                     (->str pattern)
                     pattern)))
+        (when (= "*" api-opts.pattern)
+          ;; Note: `*` is the default and redundant.
+          (tset api-opts :pattern nil))
         (let [es (if (str? events)
                      ;; Expect dot-separated format: `:BufNewFile.BufReadPost`.
                      (icollect [p (events:gmatch "[a-zA-Z]+")]


### PR DESCRIPTION
Close #21 