### PR TITLE
refactor!: interpret any symbol for callback as Vim command for autocmd/keymap macros

### DIFF
--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -536,7 +536,7 @@
                     (error* "cannot set both <command>/ex and <callback>/cb."))
                   (if (or extra-opts.<command> extra-opts.ex) raw-rhs
                       (or extra-opts.<callback> extra-opts.cb ;
-                          (sym? raw-rhs) ;
+                          (quoted? raw-rhs) ;
                           (anonymous-function? raw-rhs)) ;
                       (do
                         (set extra-opts.callback raw-rhs)

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -1247,8 +1247,7 @@
       `(let [id# (vim.api.nvim_create_augroup ,name ,opts)]
          ,(icollect [_ args (ipairs [...])]
             (let [au-args (if (and (list? args)
-                                   (contains? [`au! `autocmd!]
-                                              (first args)))
+                                   (contains? [`au! `autocmd!] (first args)))
                               (slice args 2)
                               (sequence? args)
                               args

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -105,7 +105,7 @@
   @param x any
   @return boolean"
   (and (list? x) ;
-       (contains? [:fn :hashfn :lambda :partial] (first-symbol x))))
+       (contains? [`fn `hashfn `lambda `partial] (first x))))
 
 ;; Specific Utils ///1
 
@@ -1247,8 +1247,8 @@
       `(let [id# (vim.api.nvim_create_augroup ,name ,opts)]
          ,(icollect [_ args (ipairs [...])]
             (let [au-args (if (and (list? args)
-                                   (contains? [:au! :autocmd!]
-                                              (first-symbol args)))
+                                   (contains? [`au! `autocmd!]
+                                              (first args)))
                               (slice args 2)
                               (sequence? args)
                               args

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -545,12 +545,6 @@
                           (sym? raw-rhs) ;
                           (anonymous-function? raw-rhs)) ;
                       (do
-                        ;; Hack: `->compatible-opts` must remove
-                        ;; `cb`/`<callback>` key instead, but it doesn't at
-                        ;; present. It should be reported to Fennel repository,
-                        ;; but no idea how to reproduce it in minimal codes.
-                        (set extra-opts.cb nil)
-                        (set extra-opts.<callback> nil)
                         (set extra-opts.callback raw-rhs)
                         "") ;
                       ;; Otherwise, Normal mode commands.

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -89,6 +89,11 @@
 
 ;; Additional predicates ///2
 
+(fn quoted? [x]
+  "Check if `x` is a list which begins with `quote`."
+  (and (list? x) ;
+       (= `quote (first x))))
+
 (fn anonymous-function? [x]
   "(Compile time) Check if type of `x` is anonymous function.
   @param x any

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -87,17 +87,6 @@
     (fcollect [i first last]
       (. xs i))))
 
-(lambda first-symbol [x]
-  "Return the first symbol in list `x`
-  @param x list
-  @return string"
-  ;; TODO: Check if `x` is list.
-  ;; (assert-compile (or (list? x) (table? x))
-  ;;                 (.. "expected list or table, got " (type x)) x)
-  (let [first-item (first x)]
-    (if (str? first-item) first-item ;
-        (first-symbol first-item))))
-
 ;; Additional predicates ///2
 
 (fn anonymous-function? [x]

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -1208,7 +1208,7 @@
         (if (or extra-opts.<command> extra-opts.ex)
             (set extra-opts.command callback)
             (or extra-opts.<callback> extra-opts.cb ;
-                (sym? callback) ;
+                (quoted? callback) ;
                 (anonymous-function? callback))
             ;; Note: Ignore the possibility to set Vimscript function to callback
             ;; in string; however, convert `vim.fn.foobar` into "foobar" to set


### PR DESCRIPTION
- [ ] refactor!: interpret any symbol for autocmd/keymap rhs as command
  - [x] ~~perf: extract function symbol in hashfn~~ Not planned
- [x] test: add tests for keymap with quoted callbacks
- [x] test: update deprecated tests for autocmd with quoted callbacks
- [ ] docs: update
- [x] refactor: extract callback function in quote-list
  - [x] keymap
  - [x] autocmd
- [ ] feat: deprecate redundant `<command>`, `<callback>`, ..., options