### PR TITLE
feat: extract callback in `quote`; deprecate callback in symbol

### DIFF
--- a/doc/MACROS.md
+++ b/doc/MACROS.md
@@ -126,10 +126,9 @@ Create or get an augroup, or override an existing augroup.
   at runtime), or set it in anonymous function constructed by `fn`, `hashfn`,
   `lambda`, and `partial`; otherwise, Ex command.
 
-  Note: To call Vim script function `foobar` without table arg from
-  `nvim_create_autocmd()`, just set `vim.fn.foobar`, or `` `vim.fn.foobar `` if
-  you prefer, there; on the other hand, set `#(vim.fn.foobar $)` to call
-  `foobar` with the table arg.
+  Note: Set `` `vim.fn.foobar `` to call Vim script function `foobar` without
+  table argument from `nvim_create_autocmd()`; on the other hand, set
+  `#(vim.fn.foobar $)` to call `foobar` with the table argument.
 - [`?api-opts`](#api-opts): (kv-table) `:h nvim_create_autocmd()`.
 
 ```fennel

--- a/doc/MACROS.md
+++ b/doc/MACROS.md
@@ -888,6 +888,14 @@ in another anonymous function is meaningless in many cases.
 
 ## Deprecated
 
+### v0.5.1
+
+- Symbol will no longer be an identifer as callback function for the macros,
+  [`map!`](#map!), [`autocmd!`](#autocmd), and so on; set `` `foobar `` to set a
+  symbol `foobar` as callback function instead.
+
+### v0.5.0
+
 - `nmap!`: Use [`map!`](#map) with `remap` option for corresponding mode
   instead.
 - `vmap!`: Use [`map!`](#map) with `remap` option for corresponding mode

--- a/doc/MACROS.md
+++ b/doc/MACROS.md
@@ -120,17 +120,16 @@ Create or get an augroup, or override an existing augroup.
   - `<callback>`: It indicates that `callback` must be callback function by
     itself.
   - `cb`: An alias of `<callback>` key.
-- `callback`: (string|function) Set either callback function or vim Ex command.
-  Symbol, quoted symbol/list, or anonymous function constructed by `fn`,
-  `hashfn`, `lambda`, and `partial`, is regarded as Lua function; otherwise, as
-  Ex command.
+- `callback`: (string|function) Set either callback function or Ex command. To
+  tell `callback` is Lua function, either prepend a quote `` ` `` as an
+  identifer (the quoted symbol, or list, is supposed to result in Lua function
+  at runtime), or set it in anonymous function constructed by `fn`, `hashfn`,
+  `lambda`, and `partial`; otherwise, Ex command.
 
-  Note: Insert `<command>` key in `extra-opts` to set string via symbol.
-
-  Note: Set `vim.fn.foobar`, or set `:foobar` to `callback` with `<command>` key
-  in `extra-opts`, to call Vim script function `foobar` without table arg from
-  `nvim_create_autocmd()`; instead, set `#(vim.fn.foobar $)` to call `foobar`
-  with the table arg.
+  Note: To call Vim script function `foobar` without table arg from
+  `nvim_create_autocmd()`, just set `vim.fn.foobar`, or `` `vim.fn.foobar `` if
+  you prefer, there; on the other hand, set `#(vim.fn.foobar $)` to call
+  `foobar` with the table arg.
 - [`?api-opts`](#api-opts): (kv-table) `:h nvim_create_autocmd()`.
 
 ```fennel
@@ -264,12 +263,16 @@ Map `lhs` to `rhs` in `modes`, non-recursively by default.
   - `<callback>`: It indicates that `rhs` must be callback function by itself.
   - `cb`: An alias of `<callback>` key.
 - `lhs`: (string) Left-hand-side of the mapping.
-- `rhs`: (string|function) Right-hand-side of the mapping. Symbol, quoted
-  symbol/list, or anonymous function constructed by `fn`, `hashfn`, `lambda`,
-  and `partial`, is regarded as Lua function; otherwise, as Normal mode command
-  execution.
+- `rhs`: (string|function) Right-hand-side of the mapping. Set either callback
+  function or Ex command. To tell `callback` is Lua function, either prepend a
+  quote `` ` `` as an identifer (the quoted symbol, or list, is supposed to
+  result in Lua function at runtime), or set it in anonymous function
+  constructed by `fn`, `hashfn`, `lambda`, and `partial`; otherwise, Ex command.
 
-  Note: Insert `<command>` key in `extra-opts` to set string via symbol.
+  Note: To call Vim script function `foobar` without table arg from
+  `nvim_create_autocmd()`, just set `vim.fn.foobar`, or `` `vim.fn.foobar `` if
+  you prefer, there; on the other hand, set `#(vim.fn.foobar $)` to call
+  `foobar` with the table arg.
 - [`?api-opts`](#api-opts): (kv-table) `:h nvim_set_keymap()`.
 
 ```fennel

--- a/doc/MACROS.md
+++ b/doc/MACROS.md
@@ -137,11 +137,11 @@ Create or get an augroup, or override an existing augroup.
 (augroup! :sample-augroup
   [:TextYankPost #(vim.highlight.on_yank {:timeout 450 :on_visual false})]
   (autocmd! [:InsertEnter :InsertLeave]
-      [:<buffer> :desc "call foo#bar() without any args"] vim.fn.foo#bar)
+      [:<buffer> :desc "call foo#bar() without any args"] `vim.fn.foo#bar)
   (autocmd! :VimEnter [:once :nested :desc "call baz#qux() with <amatch>"]
       #(vim.fn.baz#qux $.match)))
   (autocmd! :LspAttach
-      #(au! $.group :CursorHold [:buffer $.buf] vim.lsp.buf.document_highlight))
+      #(au! $.group :CursorHold [:buffer $.buf] `vim.lsp.buf.document_highlight))
 ```
 
 is equivalent to
@@ -271,6 +271,44 @@ Map `lhs` to `rhs` in `modes`, non-recursively by default.
 
   Note: Insert `<command>` key in `extra-opts` to set string via symbol.
 - [`?api-opts`](#api-opts): (kv-table) `:h nvim_set_keymap()`.
+
+```fennel
+(map! :i :jk :<Esc>)
+(map! :n :lhs [:desc "call foo#bar()"] `vim.fn.foo#bar)
+(map! [:n :x] [:remap :expr :literal] :d "&readonly ? '<Plug>(readonly-d)' : '<Plug>(noreadonly-d)'")
+(map! [:n :x] [:remap :expr] :u #(if vim.bo.readonly
+                                     "<Plug>(readonly-u)"
+                                     "<Plug>(noreadonly-u)"))
+```
+
+is equivalent to
+
+```vim
+inoremap jk <Esc>
+nnoremap lhs <Cmd>call foo#bar()<CR>
+nmap <expr> d &readonly ? "\<Plug>(readonly-d)" : "\<Plug>(noreadonly-d)"
+xmap <expr> u &readonly ? "\<Plug>(readonly-u)" : "\<Plug>(noreadonly-u)"
+```
+
+```lua
+vim.keymap.set("i", "jk", "<Esc>")
+vim.keymap.set("n", "lhs", function()
+  vim.fn["foo#bar"]()
+end)
+-- or, if you don't care about lazy loading,
+vim.keymap.set("n", "lhs", vim.fn["foo#bar"])
+vim.keymap.set({ "n", "x" }, "d", "&readonly ? '<Plug>(readonly-d)' : '<Plug>(noreadonly-d)'", {
+  remap = true,
+  expr = true,
+  replace_keycodes = false,
+})
+vim.keymap.set({ "n", "x" }, "u", function()
+  return vim.bo.readonly and "<Plug>(readonly-u)" or "<Plug>(noreadonly-u)"
+end, {
+  remap = true,
+  expr = true,
+})
+```
 
 #### `unmap!`
 

--- a/doc/MACROS.md
+++ b/doc/MACROS.md
@@ -121,8 +121,9 @@ Create or get an augroup, or override an existing augroup.
     itself.
   - `cb`: An alias of `<callback>` key.
 - `callback`: (string|function) Set either callback function or vim Ex command.
-  Symbol, and anonymous function constructed by `fn`, `hashfn`, `lambda`, and
-  `partial`, is regarded as Lua function; otherwise, as Ex command.
+  Symbol, quoted symbol/list, or anonymous function constructed by `fn`,
+  `hashfn`, `lambda`, and `partial`, is regarded as Lua function; otherwise, as
+  Ex command.
 
   Note: Insert `<command>` key in `extra-opts` to set string via symbol.
 
@@ -263,9 +264,10 @@ Map `lhs` to `rhs` in `modes`, non-recursively by default.
   - `<callback>`: It indicates that `rhs` must be callback function by itself.
   - `cb`: An alias of `<callback>` key.
 - `lhs`: (string) Left-hand-side of the mapping.
-- `rhs`: (string|function) Right-hand-side of the mapping. Symbol, and anonymous
-  function constructed by `fn`, `hashfn`, `lambda`, and `partial`, is regarded
-  as Lua function; otherwise, as Normal mode command execution.
+- `rhs`: (string|function) Right-hand-side of the mapping. Symbol, quoted
+  symbol/list, or anonymous function constructed by `fn`, `hashfn`, `lambda`,
+  and `partial`, is regarded as Lua function; otherwise, as Normal mode command
+  execution.
 
   Note: Insert `<command>` key in `extra-opts` to set string via symbol.
 - [`?api-opts`](#api-opts): (kv-table) `:h nvim_set_keymap()`.

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -306,7 +306,11 @@
                    ;; Note: Either vim.fn.foobar or `vim.fn.foobar should be
                    ;; "foobar" set to "callback" key.
                    (or (extract-?vim-fn-name cb) ;
-                       cb)))
+                       (if (sym? callback)
+                           (deprecate "callback function in symbol for `augroup!`, `autocmd!`, ..."
+                                      "quote \"`\" like `foobar" :v0.6.0
+                                      callback)
+                           cb))))
             (set extra-opts.command callback))
         (let [api-opts (merge-api-opts (autocmd/->compatible-opts! extra-opts)
                                        ?api-opts)]
@@ -442,8 +446,8 @@
                         (set extra-opts.callback
                              (if (sym? raw-rhs)
                                  (deprecate "callback function in symbol for `map!`"
-                                            "quote \"`\" like `foobar"
-                                            :v0.6.0 raw-rhs)
+                                            "quote \"`\" like `foobar" :v0.6.0
+                                            raw-rhs)
                                  (->unquoted raw-rhs)))
                         "") ;
                       ;; Otherwise, Normal mode commands.

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -89,6 +89,13 @@
 
 ;; Additional predicates ///2
 
+(fn quoted? [x]
+  "Check if `x` is a list which begins with `quote`.
+  @param x any
+  @return boolean"
+  (and (list? x) ;
+       (= `quote (first x))))
+
 (fn anonymous-function? [x]
   "(Compile time) Check if type of `x` is anonymous function.
   @param x any

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -169,6 +169,30 @@
       (collect [k v (pairs ?api-opts) &into ?extra-opts]
         (values k v))))
 
+(lambda ->fn [x]
+  "If quoted, return function for runtime; otherwise, just return `x` itself as
+  it's supposed to be function.
+  ```fennel
+  (->fn `foobar) ; -> foobar
+  (->fn `foo.bar) ; -> foo.bar
+  (->fn `(foo :bar)) ; -> #(foo :bar)
+  (->fn `(foobar)) ; -> #(foobar)
+  (->fn foobar) ; -> foobar
+  (->fn foo.bar) ; -> foo.bar
+  (->fn (foo :bar)) ; -> (foo :bar)
+  (->fn (foobar)) ; -> (foobar)
+  ```
+  @param x any but nil
+  @return symbol|`list Return function ideally"
+  (if (anonymous-function? x)
+      x
+      (quoted? x)
+      (let [unquoted (second x)]
+        (if (sym? unquoted)
+            unquoted
+            `#,unquoted))
+      x))
+
 (lambda extract-?vim-fn-name [x]
   "Extract \"foobar\" from multi-symbol `vim.fn.foobar`, or return `nil`.
   @param x any

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -310,7 +310,8 @@
             (set extra-opts.command callback)
             (or extra-opts.<callback> extra-opts.cb ;
                 (sym? callback) ;
-                (anonymous-function? callback))
+                (anonymous-function? callback) ;
+                (quoted? callback))
             ;; Note: Ignore the possibility to set Vimscript function to callback
             ;; in string; however, convert `vim.fn.foobar` into "foobar" to set
             ;; to "callback" key because functions written in Vim script are
@@ -318,7 +319,7 @@
             ;; its first arg.
             (set extra-opts.callback
                  (or (extract-?vim-fn-name callback) ;
-                     callback))
+                     (->fn callback)))
             (set extra-opts.command callback))
         (let [api-opts (merge-api-opts (autocmd/->compatible-opts! extra-opts)
                                        ?api-opts)]

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -317,9 +317,12 @@
             ;; to "callback" key because functions written in Vim script are
             ;; rarely supposed to expect the table from `nvim_create_autocmd` for
             ;; its first arg.
-            (set extra-opts.callback
-                 (or (extract-?vim-fn-name callback) ;
-                     (->fn callback)))
+            (let [cb (->fn callback)]
+              (set extra-opts.callback
+                   ;; Note: Either vim.fn.foobar or `vim.fn.foobar should be
+                   ;; "foobar" set to "callback" key.
+                   (or (extract-?vim-fn-name cb) ;
+                       cb)))
             (set extra-opts.command callback))
         (let [api-opts (merge-api-opts (autocmd/->compatible-opts! extra-opts)
                                        ?api-opts)]

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -160,10 +160,9 @@
   "Extract \"foobar\" from multi-symbol `vim.fn.foobar`, or return `nil`.
   @param x any
   @return string|nil"
-  (when (multi-sym? x)
-    (let [(fn-name pos) (-> (->str x) (: :gsub "^vim%.fn%." ""))]
-      (when (< 0 pos)
-        fn-name))))
+  (let [name (->str x)
+        pat-vim-fn "^vim%.fn%.(%S+)$"]
+    (name:match pat-vim-fn)))
 
 (lambda deprecate [deprecated alternative version compatible]
   "Return a wrapper function, which returns `compatible`, about to notify

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -907,11 +907,12 @@
                                       :<buffer>
                                       :register
                                       :keepscript]))
-        [extra-opts name command ?api-opts] (if-not ?extra-opts
-                                              [{} a1 a2 ?a3]
-                                              (sequence? a1)
-                                              [?extra-opts a2 ?a3 ?a4]
-                                              [?extra-opts a1 ?a3 ?a4])
+        [extra-opts name raw-command ?api-opts] (if-not ?extra-opts
+                                                  [{} a1 a2 ?a3]
+                                                  (sequence? a1)
+                                                  [?extra-opts a2 ?a3 ?a4]
+                                                  [?extra-opts a1 ?a3 ?a4])
+        command (->fn raw-command)
         ?bufnr (if extra-opts.<buffer> 0 extra-opts.buffer)
         api-opts (merge-api-opts (command/->compatible-opts! extra-opts)
                                  ?api-opts)]

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -439,7 +439,12 @@
                         ;; but no idea how to reproduce it in minimal codes.
                         (set extra-opts.cb nil)
                         (set extra-opts.<callback> nil)
-                        (set extra-opts.callback (->unquoted raw-rhs))
+                        (set extra-opts.callback
+                             (if (sym? raw-rhs)
+                                 (deprecate "callback function in symbol for `map!`"
+                                            "quote \"`\" like `foobar"
+                                            :v0.6.0 raw-rhs)
+                                 (->unquoted raw-rhs)))
                         "") ;
                       ;; Otherwise, Normal mode commands.
                       raw-rhs))

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -443,7 +443,8 @@
                   (if (or extra-opts.<command> extra-opts.ex) raw-rhs
                       (or extra-opts.<callback> extra-opts.cb ;
                           (sym? raw-rhs) ;
-                          (anonymous-function? raw-rhs)) ;
+                          (anonymous-function? raw-rhs) ;
+                          (quoted? raw-rhs))
                       (do
                         ;; Hack: `->compatible-opts` must remove
                         ;; `cb`/`<callback>` key instead, but it doesn't at
@@ -451,7 +452,7 @@
                         ;; but no idea how to reproduce it in minimal codes.
                         (set extra-opts.cb nil)
                         (set extra-opts.<callback> nil)
-                        (set extra-opts.callback raw-rhs)
+                        (set extra-opts.callback (->fn raw-rhs))
                         "") ;
                       ;; Otherwise, Normal mode commands.
                       raw-rhs))

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -76,6 +76,12 @@
   @return undefined"
   (. xs 1))
 
+(lambda second [xs]
+  "Return the second value in `xs`
+  @param xs sequence
+  @return undefined"
+  (. xs 2))
+
 (lambda slice [xs ?start ?end]
   "Return sequence from `?start` to `?end`.
   @param xs sequence

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -1,5 +1,11 @@
 (import-macros {: augroup! : augroup+ : au! : autocmd!} :nvim-laurel.macros)
 
+(macro macro-callback []
+  `#:macro-callback)
+
+(macro macro-command []
+  :macro-command)
+
 (local default-augroup :default-test-augroup)
 (local default-event :BufRead)
 (local default-callback #:default-callback)
@@ -36,6 +42,22 @@
           #(let [id (augroup! default-augroup)]
              (assert.is.same id (augroup+ default-augroup))))))
     (describe :au!/autocmd!
+      (it "must be wrapped in hashfn, fn, ..., to set callback in macro"
+        (fn []
+          (autocmd! default-augroup default-event [:pat] #(macro-callback))
+          (let [au (get-first-autocmd {:pattern :pat})]
+            (assert.is_not_nil au.callback))))
+      (it "set command in macro with no args"
+        (fn []
+          (autocmd! default-augroup default-event [:pat] (macro-command))
+          (let [au (get-first-autocmd {:pattern :pat})]
+            (assert.is_same :macro-command au.command))))
+      (it "set command in macro with some args"
+        (fn []
+          (autocmd! default-augroup default-event [:pat]
+                    (macro-command :foo :bar))
+          (let [au (get-first-autocmd {:pattern :pat})]
+            (assert.is_same :macro-command au.command))))
       (fn []
         (describe "detects 2 args:"
           (fn []

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -48,9 +48,9 @@
           #(let [id (augroup! default-augroup)]
              (assert.is.same id (augroup+ default-augroup))))))
     (describe :au!/autocmd!
-      (it "must be wrapped in hashfn, fn, ..., to set callback in macro"
+      (it "sets callback via macro with quote"
         (fn []
-          (autocmd! default-augroup default-event [:pat] #(macro-callback))
+          (autocmd! default-augroup default-event [:pat] `(macro-callback))
           (let [au (get-first-autocmd {:pattern :pat})]
             (assert.is_not_nil au.callback))))
       (it "set command in macro with no args"

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -22,6 +22,11 @@
 
 (describe :autocmd
   (fn []
+    (setup (fn []
+             (vim.cmd "function g:Test() abort
+                       endfunction")))
+    (teardown (fn []
+                (vim.cmd "delfunction g:Test")))
     (before_each (fn []
                    (augroup! default-augroup)
                    (let [aus (get-autocmds)]
@@ -160,10 +165,6 @@
               (assert.is.same "<vim function: foobar>" autocmd2.callback))))
         (it "sets vim.fn.Test to callback in string"
           (fn []
-            (vim.cmd "
-                                      function! g:Test() abort
-                                      endfunction
-                                      ")
             (assert.has_no.errors #(autocmd! default-augroup default-event
                                              vim.fn.Test))
             (let [[autocmd] (get-autocmds)]

--- a/tests/spec/command_spec.fnl
+++ b/tests/spec/command_spec.fnl
@@ -43,6 +43,19 @@
           (command! :Foo [:buffer bufnr] :Bar)
           (assert.is_not_nil (get-buf-command bufnr :Foo))
           (assert.has_no_error #(vim.api.nvim_buf_del_user_command bufnr :Foo)))))
+    (it "must be wrapped in hashfn, fn, ..., to set callback in macro"
+      (fn []
+        (command! :Foo #(macro-callback))
+        ;; TODO: Check if callback is set.
+        (assert.is_not_nil (get-command :Foo))))
+    (it "set command in macro with no args"
+      (fn []
+        (command! :Foo (macro-command))
+        (assert.is_same :macro-command (get-command-definition :Foo))))
+    (it "set command in macro with some args"
+      (fn []
+        (command! :Foo (macro-command :foo :bar))
+        (assert.is_same :macro-command (get-command-definition :Foo))))
     (describe :extra-opts
       (fn []
         (it "can be either first arg or second arg"

--- a/tests/spec/command_spec.fnl
+++ b/tests/spec/command_spec.fnl
@@ -1,8 +1,19 @@
 (import-macros {: command!} :nvim-laurel.macros)
 
+(macro macro-callback []
+  `#:macro-callback)
+
+(macro macro-command []
+  :macro-command)
+
 (lambda get-command [name]
   (-> (vim.api.nvim_get_commands {:builtin false})
       (. name)))
+
+(lambda get-command-definition [name]
+  "Return command, or value for desc if callback is Lua function.
+  Read `Parameters.opts.desc` of `:h nvim_create_user_command()`"
+  (. (get-command name) :definition))
 
 (lambda get-buf-command [bufnr name]
   (-> (vim.api.nvim_buf_get_commands bufnr {:builtin false})

--- a/tests/spec/command_spec.fnl
+++ b/tests/spec/command_spec.fnl
@@ -71,9 +71,9 @@
           (command! :Foo `vim.fn.Test)
           (assert.is_same "" (get-command-definition :Foo))
           (assert.is_not_same desc (get-command-definition :Foo)))))
-    (it "must be wrapped in hashfn, fn, ..., to set callback in macro"
+    (it "sets callback via macro with quote"
       (fn []
-        (command! :Foo #(macro-callback))
+        (command! :Foo `(macro-callback))
         ;; TODO: Check if callback is set.
         (assert.is_not_nil (get-command :Foo))))
     (it "set command in macro with no args"

--- a/tests/spec/command_spec.fnl
+++ b/tests/spec/command_spec.fnl
@@ -58,11 +58,11 @@
         (let [desc :multi.sym]
           (command! :Foo `default.multi.sym {: desc})
           (assert.is_same desc (get-command-definition :Foo)))))
-    (it "can set callback function with quoted list"
+    (it "can set quoted list result to callback"
       (fn []
         (let [desc :list]
           (command! :Foo `(default-callback :foo :bar) {: desc})
-          (assert.is_same desc (get-command-definition :Foo)))))
+          (assert.is_same (default-callback) (get-command-definition :Foo)))))
     (it "which sets callback `vim.fn.Test will not be overridden by `desc` key"
       ;; Note: The reason is probably vim.fn.Test is not a Lua function but
       ;; a Vim one.

--- a/tests/spec/command_spec.fnl
+++ b/tests/spec/command_spec.fnl
@@ -23,7 +23,8 @@
   (fn []
     (before_each (fn []
                    (pcall vim.api.nvim_del_user_command :Foo)
-                   (pcall vim.api.nvim_buf_del_user_command 0 :Foo)))
+                   (pcall vim.api.nvim_buf_del_user_command 0 :Foo)
+                   (assert.is_nil (get-command :Foo))))
     (it "defines user command"
       (fn []
         (assert.is_nil (get-command :Foo))

--- a/tests/spec/command_spec.fnl
+++ b/tests/spec/command_spec.fnl
@@ -8,53 +8,52 @@
   (-> (vim.api.nvim_buf_get_commands bufnr {:builtin false})
       (. name)))
 
-(describe :command! ;
+(describe :command!
+  (fn []
+    (before_each (fn []
+                   (pcall vim.api.nvim_del_user_command :Foo)
+                   (pcall vim.api.nvim_buf_del_user_command 0 :Foo)))
+    (it "defines user command"
+      (fn []
+        (assert.is_nil (get-command :Foo))
+        (command! :Foo :Bar)
+        (assert.is_not_nil (get-command :Foo))))
+    (it "defines local user command for current buffer with `<buffer>` attr"
+      (fn []
+        (assert.is_nil (get-buf-command 0 :Foo))
+        (command! [:<buffer>] :Foo :Bar)
+        (assert.is_not_nil (get-buf-command 0 :Foo))))
+    (it "defines local user command with buffer number"
+      (fn []
+        (let [bufnr (vim.api.nvim_get_current_buf)]
+          (assert.is_nil (get-buf-command bufnr :Foo))
+          (vim.cmd.new)
+          (vim.cmd.only)
+          (command! :Foo [:buffer bufnr] :Bar)
+          (assert.is_not_nil (get-buf-command bufnr :Foo))
+          (assert.has_no_error #(vim.api.nvim_buf_del_user_command bufnr :Foo)))))
+    (describe :extra-opts
+      (fn []
+        (it "can be either first arg or second arg"
           (fn []
-            (before_each (fn []
-                           (pcall vim.api.nvim_del_user_command :Foo)
-                           (pcall vim.api.nvim_buf_del_user_command 0 :Foo)))
-            (it "defines user command"
-                (fn []
-                  (assert.is_nil (get-command :Foo))
-                  (command! :Foo :Bar)
-                  (assert.is_not_nil (get-command :Foo))))
-            (it "defines local user command for current buffer with `<buffer>` attr"
-                (fn []
-                  (assert.is_nil (get-buf-command 0 :Foo))
-                  (command! [:<buffer>] :Foo :Bar)
-                  (assert.is_not_nil (get-buf-command 0 :Foo))))
-            (it "defines local user command with buffer number"
-                (fn []
-                  (let [bufnr (vim.api.nvim_get_current_buf)]
-                    (assert.is_nil (get-buf-command bufnr :Foo))
-                    (vim.cmd.new)
-                    (vim.cmd.only)
-                    (command! :Foo [:buffer bufnr] :Bar)
-                    (assert.is_not_nil (get-buf-command bufnr :Foo))
-                    (assert.has_no_error #(vim.api.nvim_buf_del_user_command bufnr
-                                                                             :Foo)))))
-            (describe :extra-opts
-                      (fn []
-                        (it "can be either first arg or second arg"
-                            (fn []
-                              (assert.has_no_error #(command! [:bang] :Foo :Bar))
-                              (assert.has_no_error #(command! :Foo [:bang] :Bar))))))
-            (describe :api-opts
-                      (fn []
-                        (it "gives priority api-opts over extra-opts"
-                            (fn []
-                              (command! :Foo [:bar :bang] :FooBar)
-                              (assert.is_true (-> (get-command :Foo) (. :bang)))
-                              (assert.is_true (-> (get-command :Foo) (. :bar)))
-                              (command! :Bar [:bar :bang] :FooBar {:bar false})
-                              (assert.is_false (-> (get-command :Bar) (. :bar)))
-                              (let [tbl-opts {:bar false}
-                                    fn-opts #{:bang false}]
-                                (command! :Baz [:bar :bang] :FooBar tbl-opts)
-                                (command! :Qux [:bar :bang] :FooBar (fn-opts))
-                                (let [cmd-baz (get-command :Baz)
-                                      cmd-qux (get-command :Qux)]
-                                  (assert.is_false cmd-baz.bar)
-                                  (assert.is_true cmd-baz.bang)
-                                  (assert.is_true cmd-qux.bar)
-                                  (assert.is_false cmd-qux.bang)))))))))
+            (assert.has_no_error #(command! [:bang] :Foo :Bar))
+            (assert.has_no_error #(command! :Foo [:bang] :Bar))))))
+    (describe :api-opts
+      (fn []
+        (it "gives priority api-opts over extra-opts"
+          (fn []
+            (command! :Foo [:bar :bang] :FooBar)
+            (assert.is_true (-> (get-command :Foo) (. :bang)))
+            (assert.is_true (-> (get-command :Foo) (. :bar)))
+            (command! :Bar [:bar :bang] :FooBar {:bar false})
+            (assert.is_false (-> (get-command :Bar) (. :bar)))
+            (let [tbl-opts {:bar false}
+                  fn-opts #{:bang false}]
+              (command! :Baz [:bar :bang] :FooBar tbl-opts)
+              (command! :Qux [:bar :bang] :FooBar (fn-opts))
+              (let [cmd-baz (get-command :Baz)
+                    cmd-qux (get-command :Qux)]
+                (assert.is_false cmd-baz.bar)
+                (assert.is_true cmd-baz.bang)
+                (assert.is_true cmd-qux.bar)
+                (assert.is_false cmd-qux.bang)))))))))

--- a/tests/spec/keymap_spec.fnl
+++ b/tests/spec/keymap_spec.fnl
@@ -110,9 +110,9 @@
              (each [_ m (ipairs modes)]
                (let [{: noremap} (get-mapargs m :lhs)]
                  (assert.is.same 1 noremap)))))
-        (it "must be wrapped in hashfn, fn, ..., to set callback in macro"
+        (it "sets callback via macro with quote"
           (fn []
-            (map! :n :lhs #(macro-callback))
+            (map! :n :lhs `(macro-callback))
             (assert.is_not_nil (get-callback :n :lhs))))
         (it "set command in macro with no args"
           (fn []

--- a/tests/spec/keymap_spec.fnl
+++ b/tests/spec/keymap_spec.fnl
@@ -8,6 +8,12 @@
                 : <C-u>
                 : <Cmd>} :nvim-laurel.macros)
 
+(macro macro-callback []
+  `#:macro-callback)
+
+(macro macro-command []
+  :macro-command)
+
 (local default-rhs :default-rhs)
 (local default-callback #:default-callback)
 (local new-callback #(fn []
@@ -82,6 +88,18 @@
              (each [_ m (ipairs modes)]
                (let [{: noremap} (get-mapargs m :lhs)]
                  (assert.is.same 1 noremap)))))
+        (it "must be wrapped in hashfn, fn, ..., to set callback in macro"
+          (fn []
+            (map! :n :lhs #(macro-callback))
+            (assert.is_not_nil (get-callback :n :lhs))))
+        (it "set command in macro with no args"
+          (fn []
+            (map! :n :lhs (macro-command))
+            (assert.is_same :macro-command (get-rhs :n :lhs))))
+        (it "set command in macro with some args"
+          (fn []
+            (map! :n :lhs (macro-command :foo :bar))
+            (assert.is_same :macro-command (get-rhs :n :lhs))))
         (it "maps multiple mode mappings with a sequence at once"
           #(let [modes [:n :c :t]]
              (noremap! modes :lhs :rhs)


### PR DESCRIPTION
`command!`  macro should also accept quoted callback for the analogical usage.

- [x] feat: deprecate callback in symbol; instead, encourage `` `foobar `` format.
  - [x] fix: exclude `vim.fn.foobar`.
    - [x] keymap
    - [x] autocmd
- [x] test: confirm that `->fn` can treat user-made macros properly.

- [x] feat: `` `foo `` -> foo
    - [x] autocmd
    - [x] keymap
    - [x] command
- [x] feat: `` `(foo :bar :baz) `` -> `#(foo :bar :baz)`
    - [x] autocmd
    - [x] keymap
    - [x] command
- [x] perf:  `` `vim.fn.foobar `` -> `"foobar"`
  - [x] autocmd
  - [x]  ~~keymap~~
- [x] test: add specs
    - [x] autocmd
    - [x] keymap
    - [x] command
- [x] docs: update
    - [x] autocmd
    - [x] keymap
    - [ ] command

Blocking #143