### PR TITLE
refactor!: interpret symbol as Vim Ex command in autocmd/keymap macros

### DIFF
--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -313,7 +313,6 @@
         (if (or extra-opts.<command> extra-opts.ex)
             (set extra-opts.command callback)
             (or extra-opts.<callback> extra-opts.cb ;
-                (sym? callback) ;
                 (anonymous-function? callback) ;
                 (quoted? callback))
             ;; Note: Ignore the possibility to set Vimscript function to callback
@@ -439,7 +438,6 @@
                     (error* "cannot set both <command>/ex and <callback>/cb."))
                   (if (or extra-opts.<command> extra-opts.ex) raw-rhs
                       (or extra-opts.<callback> extra-opts.cb ;
-                          (sym? raw-rhs) ;
                           (anonymous-function? raw-rhs) ;
                           (quoted? raw-rhs))
                       (do

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -154,7 +154,7 @@
         (it "sets vim.fn.Test to callback in string"
           (fn []
             (assert.has_no.errors #(autocmd! default-augroup default-event
-                                             vim.fn.Test))
+                                             `vim.fn.Test))
             (let [[autocmd] (get-autocmds)]
               (assert.is.same "<vim function: Test>" autocmd.callback))))
         (it "creates buffer-local autocmd with `buffer` key"


### PR DESCRIPTION
This PR takes over #143.

- [x] refactor!: interpret any symbol for autocmd/keymap rhs as command
  - [x] ~~perf: extract function symbol in hashfn~~ Not planned
 - [ ] test: fix outdated specs
   - [ ] keymap
   - [ ] autocmd
- [ ] test: add specs for callback in symbol
  - [ ] keymap
  - [ ] autocmd
- [ ] docs: update
- [ ] feat: deprecate redundant `<command>`, `<callback>`, ..., options