### PR TITLE
docs(readme): set urls directly to images

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,26 +2,20 @@
 
 # nvim-laurel 🌿
 
-[![badge/license]][path/to/license]
-[![badge/test]][workflow/test]
-[![badge/semver]][path/to/semver]  
-_A set of macros for Neovim config_  
-_inspired by the builtin Nvim Lua standard library and by good old Vim
-script_
+[![badge/license](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)][path/to/license]
+[![badge/test](https://img.shields.io/github/actions/workflow/status/aileot/nvim-laurel/test.yml?branch=main&label=Test&logo=github&style=flat-square)][workflow/test]
+[![badge/semver](https://img.shields.io/github/release/aileot/nvim-laurel?display_name=tag&sort=semver&label=Release)][path/to/semver]\
+_A set of macros for Neovim config_\
+_inspired by the builtin Nvim Lua standard library and by good old Vim script_
 
-![image/nvim-laurel-demo]
+![image/nvim-laurel-demo](https://user-images.githubusercontent.com/46470475/207041810-4d0afa5e-f9cc-4878-86f2-e607cff20601.png)
 
-[![badge/fennel]][url/to/fennel]
+[![badge/fennel](https://img.shields.io/badge/Powered_by_Fennel-030281?logo=Lua&style=for-the-badge)][url/to/fennel]
 
-[badge/fennel]: https://img.shields.io/badge/Powered_by_Fennel-030281?logo=Lua&style=for-the-badge
-[badge/test]: https://img.shields.io/github/actions/workflow/status/aileot/nvim-laurel/test.yml?branch=main&label=Test&logo=github&style=flat-square
-[badge/license]: https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square
-[badge/semver]: https://img.shields.io/github/release/aileot/nvim-laurel?display_name=tag&sort=semver&label=Release
 [workflow/test]: https://github.com/aileot/nvim-laurel/actions/workflows/test.yml
 [path/to/license]: ./LICENSE
 [path/to/semver]: https://github.com/aileot/nvim-laurel/releases/latest
 [url/to/fennel]: https://fennel-lang.org/
-[image/nvim-laurel-demo]: https://user-images.githubusercontent.com/46470475/207041810-4d0afa5e-f9cc-4878-86f2-e607cff20601.png
 
 </div>
 


### PR DESCRIPTION
This modification is just for `deno fmt`, which cannot format markdown file including links for image.