### PR TITLE
test(busted): reduce `fn` nesting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ help: ## Show this help
 %_spec.lua: %_spec.fnl ## Compile fnl spec file into lua
 	@$(FENNEL) \
 		--correlate \
-		--add-macro-path "$(REPO_MACRO_PATH)" \
+		--add-macro-path "$(REPO_MACRO_PATH);$(SPEC_ROOT)/?.fnl" \
 		--compile $< > $@
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,11 @@ VUSTED ?= vusted
 
 REPO_ROOT:=$(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 TEST_ROOT:=$(REPO_ROOT)/tests
+SPEC_ROOT:=$(TEST_ROOT)/spec
 
 TEST_DEPS:=$(TEST_ROOT)/.test-deps
 
-FNL_TESTS:=$(wildcard tests/spec/*_spec.fnl)
+FNL_TESTS:=$(wildcard $(SPEC_ROOT)/*_spec.fnl)
 LUA_TESTS:=$(FNL_TESTS:%.fnl=%.lua)
 
 FNL_SRC:=$(wildcard fnl/nvim-laurel/*.fnl)

--- a/tests/spec/_busted_macros.fnl
+++ b/tests/spec/_busted_macros.fnl
@@ -1,0 +1,17 @@
+(fn inject-fn [name ...]
+  `((. (require :busted) ,name (fn []
+                                 ,...))))
+
+(fn inject-desc-fn [name desc ...]
+  `((. (require :busted) ,name) ,desc
+                                (fn []
+                                  ,...)))
+
+{:after_each (partial inject-fn :after_each)
+ :before_each (partial inject-fn :before_each)
+ :expose (partial inject-desc-fn :expose)
+ :insulate (partial inject-desc-fn :insulate)
+ :it (partial inject-desc-fn :it)
+ :setup (partial inject-fn :setup)
+ :teardown (partial inject-fn :teardown)
+ :describe (partial inject-desc-fn :describe)}

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -1,4 +1,4 @@
-(import-macros {: describe} :_busted_macros)
+(import-macros {: describe : it} :_busted_macros)
 (import-macros {: augroup! : augroup+ : au! : autocmd!} :nvim-laurel.macros)
 
 (macro macro-callback []
@@ -33,200 +33,162 @@
                    (assert.is.same {} aus))))
   (describe :augroup!
     (it "returns augroup id without autocmds insides"
-      (fn []
-        (let [id (augroup! default-augroup)]
-          (assert.has_no.errors #(vim.api.nvim_del_augroup_by_id id)))))
+      (let [id (augroup! default-augroup)]
+        (assert.has_no.errors #(vim.api.nvim_del_augroup_by_id id))))
     (it "can create augroup with sequence and `au!` macro mixed"
-      (fn []
-        (assert.has_no.errors #(augroup! default-augroup
-                                 [default-event `default-callback]
-                                 (au! :FileType [:foo :bar] #:foobar))))))
+      (assert.has_no.errors #(augroup! default-augroup
+                               [default-event `default-callback]
+                               (au! :FileType [:foo :bar] #:foobar)))))
   (describe :au!/autocmd!
     (it "sets callback via macro with quote"
-      (fn []
-        (autocmd! default-augroup default-event [:pat] `(macro-callback))
-        (let [au (get-first-autocmd {:pattern :pat})]
-          (assert.is_not_nil au.callback))))
+      (autocmd! default-augroup default-event [:pat] `(macro-callback))
+      (let [au (get-first-autocmd {:pattern :pat})]
+        (assert.is_not_nil au.callback)))
     (it "set command in macro with no args"
-      (fn []
-        (autocmd! default-augroup default-event [:pat] (macro-command))
-        (let [au (get-first-autocmd {:pattern :pat})]
-          (assert.is_same :macro-command au.command))))
+      (autocmd! default-augroup default-event [:pat] (macro-command))
+      (let [au (get-first-autocmd {:pattern :pat})]
+        (assert.is_same :macro-command au.command)))
     (it "set command in macro with some args"
-      (fn []
-        (autocmd! default-augroup default-event [:pat]
-                  (macro-command :foo :bar))
-        (let [au (get-first-autocmd {:pattern :pat})]
-          (assert.is_same :macro-command au.command))))
+      (autocmd! default-augroup default-event [:pat] (macro-command :foo :bar))
+      (let [au (get-first-autocmd {:pattern :pat})]
+        (assert.is_same :macro-command au.command)))
     (it "sets callback function with quoted symbol"
-      (fn []
-        (autocmd! default-augroup default-event [:pat] `default-callback)
-        (assert.is_same default-callback
-                        (. (get-first-autocmd {:pattern :pat}) :callback))))
+      (autocmd! default-augroup default-event [:pat] `default-callback)
+      (assert.is_same default-callback
+                      (. (get-first-autocmd {:pattern :pat}) :callback)))
     (it "sets callback function with quoted multi-symbol"
-      (fn []
-        (let [desc :multi.sym]
-          (autocmd! default-augroup default-event [:pat] `default.multi.sym
-                    {: desc})
-          ;; FIXME: In vusted, callback is unexpectedly set to a string
-          ;; "<vim function: default.multi.sym>"; it must be the same as
-          ;; `default.multi.sym`.
-          (assert.is_same desc (. (get-first-autocmd {:pattern :pat}) :desc)))))
+      (let [desc :multi.sym]
+        (autocmd! default-augroup default-event [:pat] `default.multi.sym
+                  {: desc})
+        ;; FIXME: In vusted, callback is unexpectedly set to a string
+        ;; "<vim function: default.multi.sym>"; it must be the same as
+        ;; `default.multi.sym`.
+        (assert.is_same desc (. (get-first-autocmd {:pattern :pat}) :desc))))
     (it "sets callback function with quoted list"
-      (fn []
-        (let [desc :list]
-          (autocmd! default-augroup default-event [:pat]
-                    `(default-callback :foo :bar) {: desc})
-          (let [au (get-first-autocmd {:pattern :pat})]
-            (assert.is_same desc au.desc)))))
+      (let [desc :list]
+        (autocmd! default-augroup default-event [:pat]
+                  `(default-callback :foo :bar) {: desc})
+        (let [au (get-first-autocmd {:pattern :pat})]
+          (assert.is_same desc au.desc))))
     (it "set `vim.fn.Test in string \"Test\""
-      (fn []
-        (autocmd! default-augroup default-event [:pat] `vim.fn.Test)
-        (let [au (get-first-autocmd {:pattern :pat})]
-          (assert.is_same "<vim function: Test>" au.callback))))
+      (autocmd! default-augroup default-event [:pat] `vim.fn.Test)
+      (let [au (get-first-autocmd {:pattern :pat})]
+        (assert.is_same "<vim function: Test>" au.callback)))
     (it "set #(vim.fn.Test) to callback without modification"
-      (fn []
-        (autocmd! default-augroup default-event [:pat] #(vim.fn.Test))
-        (let [au (get-first-autocmd {:pattern :pat})]
-          (assert.is_not_same "<vim function: Test>" au.callback))))
+      (autocmd! default-augroup default-event [:pat] #(vim.fn.Test))
+      (let [au (get-first-autocmd {:pattern :pat})]
+        (assert.is_not_same "<vim function: Test>" au.callback)))
     (it "can add an autocmd to an existing augroup"
-      (fn []
-        (autocmd! default-augroup default-event [:pat1 :pat2] `default-callback)
-        (let [[autocmd] (get-autocmds)]
-          (assert.is.same default-callback autocmd.callback))))
+      (autocmd! default-augroup default-event [:pat1 :pat2] `default-callback)
+      (let [[autocmd] (get-autocmds)]
+        (assert.is.same default-callback autocmd.callback)))
     (it "can add autocmd with no patterns for macro"
-      (fn []
-        (assert.has_no.errors #(autocmd! default-augroup default-event
-                                         `default-callback))))
+      (assert.has_no.errors #(autocmd! default-augroup default-event
+                                       `default-callback)))
     (it "can add autocmds to an existing augroup within `augroup+`"
-      (fn []
-        (augroup+ default-augroup
-                  (au! default-event [:pat1 :pat2] `default-callback))
-        (let [[autocmd] (get-autocmds)]
-          (assert.is.same default-callback autocmd.callback))))
+      (augroup+ default-augroup
+                (au! default-event [:pat1 :pat2] `default-callback))
+      (let [[autocmd] (get-autocmds)]
+        (assert.is.same default-callback autocmd.callback)))
     (it "can set Ex command in autocmds with `<command>` key"
-      (fn []
-        (augroup! default-augroup
-          (au! default-event [:pat1] [:<command>] default-command)
-          (au! default-event [:pat2] [:<command>] (.. :foo :bar)))
-        (let [[autocmd1] (get-autocmds {:pattern :pat1})
-              [autocmd2] (get-autocmds {:pattern :pat2})]
-          (assert.is.same default-command autocmd1.command)
-          (assert.is.same :foobar autocmd2.command))))
+      (augroup! default-augroup
+        (au! default-event [:pat1] [:<command>] default-command)
+        (au! default-event [:pat2] [:<command>] (.. :foo :bar)))
+      (let [[autocmd1] (get-autocmds {:pattern :pat1})
+            [autocmd2] (get-autocmds {:pattern :pat2})]
+        (assert.is.same default-command autocmd1.command)
+        (assert.is.same :foobar autocmd2.command)))
     (it "can set Ex command in autocmds with `ex` key"
-      (fn []
-        (augroup! default-augroup
-          (au! default-event [:pat1] [:ex] default-command)
-          (au! default-event [:pat2] [:ex] (.. :foo :bar)))
-        (let [[autocmd1] (get-autocmds {:pattern :pat1})
-              [autocmd2] (get-autocmds {:pattern :pat2})]
-          (assert.is.same default-command autocmd1.command)
-          (assert.is.same :foobar autocmd2.command))))
+      (augroup! default-augroup
+        (au! default-event [:pat1] [:ex] default-command)
+        (au! default-event [:pat2] [:ex] (.. :foo :bar)))
+      (let [[autocmd1] (get-autocmds {:pattern :pat1})
+            [autocmd2] (get-autocmds {:pattern :pat2})]
+        (assert.is.same default-command autocmd1.command)
+        (assert.is.same :foobar autocmd2.command)))
     (it "can set callback function in autocmds with `<callback>` key"
-      (fn []
-        (augroup! default-augroup
-          (au! default-event [:pat1] [:<callback>] `default-callback)
-          (au! default-event [:pat2] [:<callback>] (.. :foo :bar)))
-        (let [[autocmd1] (get-autocmds {:pattern :pat1})
-              [autocmd2] (get-autocmds {:pattern :pat2})]
-          (assert.is.same default-callback autocmd1.callback)
-          (assert.is.same "<vim function: foobar>" autocmd2.callback))))
+      (augroup! default-augroup
+        (au! default-event [:pat1] [:<callback>] `default-callback)
+        (au! default-event [:pat2] [:<callback>] (.. :foo :bar)))
+      (let [[autocmd1] (get-autocmds {:pattern :pat1})
+            [autocmd2] (get-autocmds {:pattern :pat2})]
+        (assert.is.same default-callback autocmd1.callback)
+        (assert.is.same "<vim function: foobar>" autocmd2.callback)))
     (it "can set callback function in autocmds with `cb` key"
-      (fn []
-        (augroup! default-augroup
-          (au! default-event [:pat1] [:cb] `default-callback)
-          (au! default-event [:pat2] [:cb] (.. :foo :bar)))
-        (let [[autocmd1] (get-autocmds {:pattern :pat1})
-              [autocmd2] (get-autocmds {:pattern :pat2})]
-          (assert.is.same default-callback autocmd1.callback)
-          (assert.is.same "<vim function: foobar>" autocmd2.callback))))
+      (augroup! default-augroup
+        (au! default-event [:pat1] [:cb] `default-callback)
+        (au! default-event [:pat2] [:cb] (.. :foo :bar)))
+      (let [[autocmd1] (get-autocmds {:pattern :pat1})
+            [autocmd2] (get-autocmds {:pattern :pat2})]
+        (assert.is.same default-callback autocmd1.callback)
+        (assert.is.same "<vim function: foobar>" autocmd2.callback)))
     (it "sets vim.fn.Test to callback in string"
-      (fn []
-        (assert.has_no.errors #(autocmd! default-augroup default-event
-                                         vim.fn.Test))
-        (let [[autocmd] (get-autocmds)]
-          (assert.is.same "<vim function: Test>" autocmd.callback))))
+      (assert.has_no.errors #(autocmd! default-augroup default-event
+                                       vim.fn.Test))
+      (let [[autocmd] (get-autocmds)]
+        (assert.is.same "<vim function: Test>" autocmd.callback)))
     (it "creates buffer-local autocmd with `buffer` key"
-      (fn []
-        (let [bufnr (vim.api.nvim_get_current_buf)
-              au1 (au! default-augroup default-event [:buffer bufnr]
-                       `default-callback)]
-          (vim.cmd.new)
-          (vim.cmd.only)
-          (let [au2 (au! default-augroup default-event [:<buffer>]
-                         `default-callback)
-                [autocmd1] (get-autocmds {:buffer bufnr})
-                [autocmd2] ;
-                (get-autocmds {:buffer (vim.api.nvim_get_current_buf)})]
-            (assert.is.same au1 autocmd1.id)
-            (assert.is.same au2 autocmd2.id)))))
+      (let [bufnr (vim.api.nvim_get_current_buf)
+            au1 (au! default-augroup default-event [:buffer bufnr]
+                     `default-callback)]
+        (vim.cmd.new)
+        (vim.cmd.only)
+        (let [au2 (au! default-augroup default-event [:<buffer>]
+                       `default-callback)
+              [autocmd1] (get-autocmds {:buffer bufnr})
+              [autocmd2] ;
+              (get-autocmds {:buffer (vim.api.nvim_get_current_buf)})]
+          (assert.is.same au1 autocmd1.id)
+          (assert.is.same au2 autocmd2.id))))
     (it "can define autocmd without any augroup"
-      (fn []
-        (assert.has_no.errors #(let [id (au! nil default-event
-                                             `default-callback)]
-                                 (vim.api.nvim_del_autocmd id)))))
+      (assert.has_no.errors #(let [id (au! nil default-event `default-callback)]
+                               (vim.api.nvim_del_autocmd id))))
     (it "gives lowest priority to `pattern` as (< raw seq tbl)"
-      (fn []
-        (let [seq-pat :seq-pat
-              tbl-pat :tbl-pat]
-          (au! default-augroup default-event [:raw-seq-pat] `default-callback)
-          (au! default-augroup default-event [:pattern seq-pat]
-               `default-callback)
-          (au! default-augroup default-event `default-callback
-               {:pattern tbl-pat})
-          (let [au (get-first-autocmd {:pattern [:raw-seq-pat]})]
-            (assert.is.same :raw-seq-pat au.pattern))
-          (let [au (get-first-autocmd {:pattern seq-pat})]
-            (assert.is.same seq-pat au.pattern))
-          (let [au (get-first-autocmd {:pattern tbl-pat})]
-            (assert.is.same tbl-pat au.pattern)))))
+      (let [seq-pat :seq-pat
+            tbl-pat :tbl-pat]
+        (au! default-augroup default-event [:raw-seq-pat] `default-callback)
+        (au! default-augroup default-event [:pattern seq-pat] `default-callback)
+        (au! default-augroup default-event `default-callback {:pattern tbl-pat})
+        (let [au (get-first-autocmd {:pattern [:raw-seq-pat]})]
+          (assert.is.same :raw-seq-pat au.pattern))
+        (let [au (get-first-autocmd {:pattern seq-pat})]
+          (assert.is.same seq-pat au.pattern))
+        (let [au (get-first-autocmd {:pattern tbl-pat})]
+          (assert.is.same tbl-pat au.pattern))))
     (describe "detects 2 args:"
       (it "sequence pattern and string callback"
-        (fn []
-          (autocmd! default-augroup default-event [:pat] :callback)))
+        (autocmd! default-augroup default-event [:pat] :callback))
       (it "sequence pattern and function callback"
-        (fn []
-          (autocmd! default-augroup default-event [:pat] #:callback)))
+        (autocmd! default-augroup default-event [:pat] #:callback))
       (it "sequence pattern and symbol callback"
-        (fn []
-          (let [cb :callback]
-            (autocmd! default-augroup default-event [:pat] cb))))
+        (let [cb :callback]
+          (autocmd! default-augroup default-event [:pat] cb)))
       (it "extra-opts and string callback"
-        (fn []
-          (autocmd! default-augroup default-event [:pat] :callback)))
+        (autocmd! default-augroup default-event [:pat] :callback))
       (it "extra-opts and function callback"
-        (fn []
-          (autocmd! default-augroup default-event [:pat] #:callback)))
+        (autocmd! default-augroup default-event [:pat] #:callback))
       (it "extra-opts and symbol callback"
-        (fn []
-          (let [cb :callback]
-            (autocmd! default-augroup default-event [:pat] cb))))
+        (let [cb :callback]
+          (autocmd! default-augroup default-event [:pat] cb)))
       (it "string callback and api-opts in table"
-        (fn []
-          (autocmd! default-augroup default-event :callback {:nested true})))
+        (autocmd! default-augroup default-event :callback {:nested true}))
       (it "string callback and api-opts in symbol"
-        (fn []
-          (let [opts {:nested true}]
-            (autocmd! default-augroup default-event :callback opts))))
+        (let [opts {:nested true}]
+          (autocmd! default-augroup default-event :callback opts)))
       (it "function callback and api-opts in table"
-        (fn []
-          (autocmd! default-augroup default-event #:callback {:nested true})))
+        (autocmd! default-augroup default-event #:callback {:nested true}))
       (it "function callback and api-opts in symbol"
-        (fn []
-          (let [opts {:nested true}]
-            (autocmd! default-augroup default-event #:callback opts))))
+        (let [opts {:nested true}]
+          (autocmd! default-augroup default-event #:callback opts)))
       (it "symbol callback and api-opts in table"
-        (fn []
-          (let [cb :callback]
-            (autocmd! default-augroup default-event cb {:nested true}))))
+        (let [cb :callback]
+          (autocmd! default-augroup default-event cb {:nested true})))
       (it "symbol callback and api-opts in symbol"
-        (fn []
-          (let [cb :callback
-                opts {:nested true}]
-            (autocmd! default-augroup default-event cb opts))))))
+        (let [cb :callback
+              opts {:nested true}]
+          (autocmd! default-augroup default-event cb opts)))))
   (describe "(deprecated)"
     (describe :augroup+
       (it "gets an existing augroup id"
-        (fn []
-          (let [id (augroup! default-augroup)]
-            (assert.is.same id (augroup+ default-augroup))))))))
+        (let [id (augroup! default-augroup)]
+          (assert.is.same id (augroup+ default-augroup)))))))

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -1,3 +1,4 @@
+(import-macros {: describe} :_busted_macros)
 (import-macros {: augroup! : augroup+ : au! : autocmd!} :nvim-laurel.macros)
 
 (macro macro-callback []
@@ -22,222 +23,210 @@
   (. (get-autocmds ?opts) 1))
 
 (describe :autocmd
-  (fn []
-    (setup (fn []
-             (vim.cmd "function g:Test() abort
-                       endfunction")))
-    (teardown (fn []
-                (vim.cmd "delfunction g:Test")))
-    (before_each (fn []
-                   (augroup! default-augroup)
-                   (let [aus (get-autocmds)]
-                     (assert.is.same {} aus))))
-    (describe :augroup!
+  (setup (fn []
+           (vim.cmd "function g:Test() abort\nendfunction")))
+  (teardown (fn []
+              (vim.cmd "delfunction g:Test")))
+  (before_each (fn []
+                 (augroup! default-augroup)
+                 (let [aus (get-autocmds)]
+                   (assert.is.same {} aus))))
+  (describe :augroup!
+    (it "returns augroup id without autocmds insides"
       (fn []
-        (it "returns augroup id without autocmds insides"
-          (fn []
-            (let [id (augroup! default-augroup)]
-              (assert.has_no.errors #(vim.api.nvim_del_augroup_by_id id)))))
-        (it "can create augroup with sequence and `au!` macro mixed"
-          (fn []
-            (assert.has_no.errors #(augroup! default-augroup
-                                     [default-event `default-callback]
-                                     (au! :FileType [:foo :bar] #:foobar)))))))
-    (describe :au!/autocmd!
+        (let [id (augroup! default-augroup)]
+          (assert.has_no.errors #(vim.api.nvim_del_augroup_by_id id)))))
+    (it "can create augroup with sequence and `au!` macro mixed"
       (fn []
-        (it "sets callback via macro with quote"
-          (fn []
-            (autocmd! default-augroup default-event [:pat] `(macro-callback))
-            (let [au (get-first-autocmd {:pattern :pat})]
-              (assert.is_not_nil au.callback))))
-        (it "set command in macro with no args"
-          (fn []
-            (autocmd! default-augroup default-event [:pat] (macro-command))
-            (let [au (get-first-autocmd {:pattern :pat})]
-              (assert.is_same :macro-command au.command))))
-        (it "set command in macro with some args"
-          (fn []
-            (autocmd! default-augroup default-event [:pat]
-                      (macro-command :foo :bar))
-            (let [au (get-first-autocmd {:pattern :pat})]
-              (assert.is_same :macro-command au.command))))
-        (it "sets callback function with quoted symbol"
-          (fn []
-            (autocmd! default-augroup default-event [:pat] `default-callback)
-            (assert.is_same default-callback
-                            (. (get-first-autocmd {:pattern :pat}) :callback))))
-        (it "sets callback function with quoted multi-symbol"
-          (fn []
-            (let [desc :multi.sym]
-              (autocmd! default-augroup default-event [:pat] `default.multi.sym
-                        {: desc})
-              ;; FIXME: In vusted, callback is unexpectedly set to a string
-              ;; "<vim function: default.multi.sym>"; it must be the same as
-              ;; `default.multi.sym`.
-              (assert.is_same desc
-                              (. (get-first-autocmd {:pattern :pat}) :desc)))))
-        (it "sets callback function with quoted list"
-          (fn []
-            (let [desc :list]
-              (autocmd! default-augroup default-event [:pat]
-                        `(default-callback :foo :bar) {: desc})
-              (let [au (get-first-autocmd {:pattern :pat})]
-                (assert.is_same desc au.desc)))))
-        (it "set `vim.fn.Test in string \"Test\""
-          (fn []
-            (autocmd! default-augroup default-event [:pat] `vim.fn.Test)
-            (let [au (get-first-autocmd {:pattern :pat})]
-              (assert.is_same "<vim function: Test>" au.callback))))
-        (it "set #(vim.fn.Test) to callback without modification"
-          (fn []
-            (autocmd! default-augroup default-event [:pat] #(vim.fn.Test))
-            (let [au (get-first-autocmd {:pattern :pat})]
-              (assert.is_not_same "<vim function: Test>" au.callback))))
-        (it "can add an autocmd to an existing augroup"
-          (fn []
-            (autocmd! default-augroup default-event [:pat1 :pat2]
-                      `default-callback)
-            (let [[autocmd] (get-autocmds)]
-              (assert.is.same default-callback autocmd.callback))))
-        (it "can add autocmd with no patterns for macro"
-          (fn []
-            (assert.has_no.errors #(autocmd! default-augroup default-event
-                                             `default-callback))))
-        (it "can add autocmds to an existing augroup within `augroup+`"
-          (fn []
-            (augroup+ default-augroup
-                      (au! default-event [:pat1 :pat2] `default-callback))
-            (let [[autocmd] (get-autocmds)]
-              (assert.is.same default-callback autocmd.callback))))
-        (it "can set Ex command in autocmds with `<command>` key"
-          (fn []
-            (augroup! default-augroup
-              (au! default-event [:pat1] [:<command>] default-command)
-              (au! default-event [:pat2] [:<command>] (.. :foo :bar)))
-            (let [[autocmd1] (get-autocmds {:pattern :pat1})
-                  [autocmd2] (get-autocmds {:pattern :pat2})]
-              (assert.is.same default-command autocmd1.command)
-              (assert.is.same :foobar autocmd2.command))))
-        (it "can set Ex command in autocmds with `ex` key"
-          (fn []
-            (augroup! default-augroup
-              (au! default-event [:pat1] [:ex] default-command)
-              (au! default-event [:pat2] [:ex] (.. :foo :bar)))
-            (let [[autocmd1] (get-autocmds {:pattern :pat1})
-                  [autocmd2] (get-autocmds {:pattern :pat2})]
-              (assert.is.same default-command autocmd1.command)
-              (assert.is.same :foobar autocmd2.command))))
-        (it "can set callback function in autocmds with `<callback>` key"
-          (fn []
-            (augroup! default-augroup
-              (au! default-event [:pat1] [:<callback>] `default-callback)
-              (au! default-event [:pat2] [:<callback>] (.. :foo :bar)))
-            (let [[autocmd1] (get-autocmds {:pattern :pat1})
-                  [autocmd2] (get-autocmds {:pattern :pat2})]
-              (assert.is.same default-callback autocmd1.callback)
-              (assert.is.same "<vim function: foobar>" autocmd2.callback))))
-        (it "can set callback function in autocmds with `cb` key"
-          (fn []
-            (augroup! default-augroup
-              (au! default-event [:pat1] [:cb] `default-callback)
-              (au! default-event [:pat2] [:cb] (.. :foo :bar)))
-            (let [[autocmd1] (get-autocmds {:pattern :pat1})
-                  [autocmd2] (get-autocmds {:pattern :pat2})]
-              (assert.is.same default-callback autocmd1.callback)
-              (assert.is.same "<vim function: foobar>" autocmd2.callback))))
-        (it "sets vim.fn.Test to callback in string"
-          (fn []
-            (assert.has_no.errors #(autocmd! default-augroup default-event
-                                             vim.fn.Test))
-            (let [[autocmd] (get-autocmds)]
-              (assert.is.same "<vim function: Test>" autocmd.callback))))
-        (it "creates buffer-local autocmd with `buffer` key"
-          (fn []
-            (let [bufnr (vim.api.nvim_get_current_buf)
-                  au1 (au! default-augroup default-event [:buffer bufnr]
-                           `default-callback)]
-              (vim.cmd.new)
-              (vim.cmd.only)
-              (let [au2 (au! default-augroup default-event [:<buffer>]
-                             `default-callback)
-                    [autocmd1] (get-autocmds {:buffer bufnr})
-                    [autocmd2] ;
-                    (get-autocmds {:buffer (vim.api.nvim_get_current_buf)})]
-                (assert.is.same au1 autocmd1.id)
-                (assert.is.same au2 autocmd2.id)))))
-        (it "can define autocmd without any augroup"
-          (fn []
-            (assert.has_no.errors #(let [id (au! nil default-event
-                                                 `default-callback)]
-                                     (vim.api.nvim_del_autocmd id)))))
-        (it "gives lowest priority to `pattern` as (< raw seq tbl)"
-          (fn []
-            (let [seq-pat :seq-pat
-                  tbl-pat :tbl-pat]
-              (au! default-augroup default-event [:raw-seq-pat]
-                   `default-callback)
-              (au! default-augroup default-event [:pattern seq-pat]
-                   `default-callback)
-              (au! default-augroup default-event `default-callback
-                   {:pattern tbl-pat})
-              (let [au (get-first-autocmd {:pattern [:raw-seq-pat]})]
-                (assert.is.same :raw-seq-pat au.pattern))
-              (let [au (get-first-autocmd {:pattern seq-pat})]
-                (assert.is.same seq-pat au.pattern))
-              (let [au (get-first-autocmd {:pattern tbl-pat})]
-                (assert.is.same tbl-pat au.pattern)))))
-        (describe "detects 2 args:"
-          (fn []
-            (it "sequence pattern and string callback"
-              (fn []
-                (autocmd! default-augroup default-event [:pat] :callback)))
-            (it "sequence pattern and function callback"
-              (fn []
-                (autocmd! default-augroup default-event [:pat] #:callback)))
-            (it "sequence pattern and symbol callback"
-              (fn []
-                (let [cb :callback]
-                  (autocmd! default-augroup default-event [:pat] cb))))
-            (it "extra-opts and string callback"
-              (fn []
-                (autocmd! default-augroup default-event [:pat] :callback)))
-            (it "extra-opts and function callback"
-              (fn []
-                (autocmd! default-augroup default-event [:pat] #:callback)))
-            (it "extra-opts and symbol callback"
-              (fn []
-                (let [cb :callback]
-                  (autocmd! default-augroup default-event [:pat] cb))))
-            (it "string callback and api-opts in table"
-              (fn []
-                (autocmd! default-augroup default-event :callback
-                          {:nested true})))
-            (it "string callback and api-opts in symbol"
-              (fn []
-                (let [opts {:nested true}]
-                  (autocmd! default-augroup default-event :callback opts))))
-            (it "function callback and api-opts in table"
-              (fn []
-                (autocmd! default-augroup default-event #:callback
-                          {:nested true})))
-            (it "function callback and api-opts in symbol"
-              (fn []
-                (let [opts {:nested true}]
-                  (autocmd! default-augroup default-event #:callback opts))))
-            (it "symbol callback and api-opts in table"
-              (fn []
-                (let [cb :callback]
-                  (autocmd! default-augroup default-event cb {:nested true}))))
-            (it "symbol callback and api-opts in symbol"
-              (fn []
-                (let [cb :callback
-                      opts {:nested true}]
-                  (autocmd! default-augroup default-event cb opts))))))))
-    (describe "(deprecated)"
+        (assert.has_no.errors #(augroup! default-augroup
+                                 [default-event `default-callback]
+                                 (au! :FileType [:foo :bar] #:foobar))))))
+  (describe :au!/autocmd!
+    (it "sets callback via macro with quote"
       (fn []
-        (describe :augroup+
-          (fn []
-            (it "gets an existing augroup id"
-              (fn []
-                (let [id (augroup! default-augroup)]
-                  (assert.is.same id (augroup+ default-augroup)))))))))))
+        (autocmd! default-augroup default-event [:pat] `(macro-callback))
+        (let [au (get-first-autocmd {:pattern :pat})]
+          (assert.is_not_nil au.callback))))
+    (it "set command in macro with no args"
+      (fn []
+        (autocmd! default-augroup default-event [:pat] (macro-command))
+        (let [au (get-first-autocmd {:pattern :pat})]
+          (assert.is_same :macro-command au.command))))
+    (it "set command in macro with some args"
+      (fn []
+        (autocmd! default-augroup default-event [:pat]
+                  (macro-command :foo :bar))
+        (let [au (get-first-autocmd {:pattern :pat})]
+          (assert.is_same :macro-command au.command))))
+    (it "sets callback function with quoted symbol"
+      (fn []
+        (autocmd! default-augroup default-event [:pat] `default-callback)
+        (assert.is_same default-callback
+                        (. (get-first-autocmd {:pattern :pat}) :callback))))
+    (it "sets callback function with quoted multi-symbol"
+      (fn []
+        (let [desc :multi.sym]
+          (autocmd! default-augroup default-event [:pat] `default.multi.sym
+                    {: desc})
+          ;; FIXME: In vusted, callback is unexpectedly set to a string
+          ;; "<vim function: default.multi.sym>"; it must be the same as
+          ;; `default.multi.sym`.
+          (assert.is_same desc (. (get-first-autocmd {:pattern :pat}) :desc)))))
+    (it "sets callback function with quoted list"
+      (fn []
+        (let [desc :list]
+          (autocmd! default-augroup default-event [:pat]
+                    `(default-callback :foo :bar) {: desc})
+          (let [au (get-first-autocmd {:pattern :pat})]
+            (assert.is_same desc au.desc)))))
+    (it "set `vim.fn.Test in string \"Test\""
+      (fn []
+        (autocmd! default-augroup default-event [:pat] `vim.fn.Test)
+        (let [au (get-first-autocmd {:pattern :pat})]
+          (assert.is_same "<vim function: Test>" au.callback))))
+    (it "set #(vim.fn.Test) to callback without modification"
+      (fn []
+        (autocmd! default-augroup default-event [:pat] #(vim.fn.Test))
+        (let [au (get-first-autocmd {:pattern :pat})]
+          (assert.is_not_same "<vim function: Test>" au.callback))))
+    (it "can add an autocmd to an existing augroup"
+      (fn []
+        (autocmd! default-augroup default-event [:pat1 :pat2] `default-callback)
+        (let [[autocmd] (get-autocmds)]
+          (assert.is.same default-callback autocmd.callback))))
+    (it "can add autocmd with no patterns for macro"
+      (fn []
+        (assert.has_no.errors #(autocmd! default-augroup default-event
+                                         `default-callback))))
+    (it "can add autocmds to an existing augroup within `augroup+`"
+      (fn []
+        (augroup+ default-augroup
+                  (au! default-event [:pat1 :pat2] `default-callback))
+        (let [[autocmd] (get-autocmds)]
+          (assert.is.same default-callback autocmd.callback))))
+    (it "can set Ex command in autocmds with `<command>` key"
+      (fn []
+        (augroup! default-augroup
+          (au! default-event [:pat1] [:<command>] default-command)
+          (au! default-event [:pat2] [:<command>] (.. :foo :bar)))
+        (let [[autocmd1] (get-autocmds {:pattern :pat1})
+              [autocmd2] (get-autocmds {:pattern :pat2})]
+          (assert.is.same default-command autocmd1.command)
+          (assert.is.same :foobar autocmd2.command))))
+    (it "can set Ex command in autocmds with `ex` key"
+      (fn []
+        (augroup! default-augroup
+          (au! default-event [:pat1] [:ex] default-command)
+          (au! default-event [:pat2] [:ex] (.. :foo :bar)))
+        (let [[autocmd1] (get-autocmds {:pattern :pat1})
+              [autocmd2] (get-autocmds {:pattern :pat2})]
+          (assert.is.same default-command autocmd1.command)
+          (assert.is.same :foobar autocmd2.command))))
+    (it "can set callback function in autocmds with `<callback>` key"
+      (fn []
+        (augroup! default-augroup
+          (au! default-event [:pat1] [:<callback>] `default-callback)
+          (au! default-event [:pat2] [:<callback>] (.. :foo :bar)))
+        (let [[autocmd1] (get-autocmds {:pattern :pat1})
+              [autocmd2] (get-autocmds {:pattern :pat2})]
+          (assert.is.same default-callback autocmd1.callback)
+          (assert.is.same "<vim function: foobar>" autocmd2.callback))))
+    (it "can set callback function in autocmds with `cb` key"
+      (fn []
+        (augroup! default-augroup
+          (au! default-event [:pat1] [:cb] `default-callback)
+          (au! default-event [:pat2] [:cb] (.. :foo :bar)))
+        (let [[autocmd1] (get-autocmds {:pattern :pat1})
+              [autocmd2] (get-autocmds {:pattern :pat2})]
+          (assert.is.same default-callback autocmd1.callback)
+          (assert.is.same "<vim function: foobar>" autocmd2.callback))))
+    (it "sets vim.fn.Test to callback in string"
+      (fn []
+        (assert.has_no.errors #(autocmd! default-augroup default-event
+                                         vim.fn.Test))
+        (let [[autocmd] (get-autocmds)]
+          (assert.is.same "<vim function: Test>" autocmd.callback))))
+    (it "creates buffer-local autocmd with `buffer` key"
+      (fn []
+        (let [bufnr (vim.api.nvim_get_current_buf)
+              au1 (au! default-augroup default-event [:buffer bufnr]
+                       `default-callback)]
+          (vim.cmd.new)
+          (vim.cmd.only)
+          (let [au2 (au! default-augroup default-event [:<buffer>]
+                         `default-callback)
+                [autocmd1] (get-autocmds {:buffer bufnr})
+                [autocmd2] ;
+                (get-autocmds {:buffer (vim.api.nvim_get_current_buf)})]
+            (assert.is.same au1 autocmd1.id)
+            (assert.is.same au2 autocmd2.id)))))
+    (it "can define autocmd without any augroup"
+      (fn []
+        (assert.has_no.errors #(let [id (au! nil default-event
+                                             `default-callback)]
+                                 (vim.api.nvim_del_autocmd id)))))
+    (it "gives lowest priority to `pattern` as (< raw seq tbl)"
+      (fn []
+        (let [seq-pat :seq-pat
+              tbl-pat :tbl-pat]
+          (au! default-augroup default-event [:raw-seq-pat] `default-callback)
+          (au! default-augroup default-event [:pattern seq-pat]
+               `default-callback)
+          (au! default-augroup default-event `default-callback
+               {:pattern tbl-pat})
+          (let [au (get-first-autocmd {:pattern [:raw-seq-pat]})]
+            (assert.is.same :raw-seq-pat au.pattern))
+          (let [au (get-first-autocmd {:pattern seq-pat})]
+            (assert.is.same seq-pat au.pattern))
+          (let [au (get-first-autocmd {:pattern tbl-pat})]
+            (assert.is.same tbl-pat au.pattern)))))
+    (describe "detects 2 args:"
+      (it "sequence pattern and string callback"
+        (fn []
+          (autocmd! default-augroup default-event [:pat] :callback)))
+      (it "sequence pattern and function callback"
+        (fn []
+          (autocmd! default-augroup default-event [:pat] #:callback)))
+      (it "sequence pattern and symbol callback"
+        (fn []
+          (let [cb :callback]
+            (autocmd! default-augroup default-event [:pat] cb))))
+      (it "extra-opts and string callback"
+        (fn []
+          (autocmd! default-augroup default-event [:pat] :callback)))
+      (it "extra-opts and function callback"
+        (fn []
+          (autocmd! default-augroup default-event [:pat] #:callback)))
+      (it "extra-opts and symbol callback"
+        (fn []
+          (let [cb :callback]
+            (autocmd! default-augroup default-event [:pat] cb))))
+      (it "string callback and api-opts in table"
+        (fn []
+          (autocmd! default-augroup default-event :callback {:nested true})))
+      (it "string callback and api-opts in symbol"
+        (fn []
+          (let [opts {:nested true}]
+            (autocmd! default-augroup default-event :callback opts))))
+      (it "function callback and api-opts in table"
+        (fn []
+          (autocmd! default-augroup default-event #:callback {:nested true})))
+      (it "function callback and api-opts in symbol"
+        (fn []
+          (let [opts {:nested true}]
+            (autocmd! default-augroup default-event #:callback opts))))
+      (it "symbol callback and api-opts in table"
+        (fn []
+          (let [cb :callback]
+            (autocmd! default-augroup default-event cb {:nested true}))))
+      (it "symbol callback and api-opts in symbol"
+        (fn []
+          (let [cb :callback
+                opts {:nested true}]
+            (autocmd! default-augroup default-event cb opts))))))
+  (describe "(deprecated)"
+    (describe :augroup+
+      (it "gets an existing augroup id"
+        (fn []
+          (let [id (augroup! default-augroup)]
+            (assert.is.same id (augroup+ default-augroup))))))))

--- a/tests/spec/command_spec.fnl
+++ b/tests/spec/command_spec.fnl
@@ -1,3 +1,4 @@
+(import-macros {: describe} :_busted_macros)
 (import-macros {: command!} :nvim-laurel.macros)
 
 (macro macro-callback []
@@ -23,89 +24,86 @@
       (. name)))
 
 (describe :command!
-  (fn []
-    (before_each (fn []
-                   (pcall vim.api.nvim_del_user_command :Foo)
-                   (pcall vim.api.nvim_buf_del_user_command 0 :Foo)
-                   (assert.is_nil (get-command :Foo))))
-    (it "defines user command"
+  (before_each (fn []
+                 (pcall vim.api.nvim_del_user_command :Foo)
+                 (pcall vim.api.nvim_buf_del_user_command 0 :Foo)
+                 (assert.is_nil (get-command :Foo))))
+  (it "defines user command"
+    (fn []
+      (assert.is_nil (get-command :Foo))
+      (command! :Foo :Bar)
+      (assert.is_not_nil (get-command :Foo))))
+  (it "defines local user command for current buffer with `<buffer>` attr"
+    (fn []
+      (assert.is_nil (get-buf-command 0 :Foo))
+      (command! [:<buffer>] :Foo :Bar)
+      (assert.is_not_nil (get-buf-command 0 :Foo))))
+  (it "defines local user command with buffer number"
+    (fn []
+      (let [bufnr (vim.api.nvim_get_current_buf)]
+        (assert.is_nil (get-buf-command bufnr :Foo))
+        (vim.cmd.new)
+        (vim.cmd.only)
+        (command! :Foo [:buffer bufnr] :Bar)
+        (assert.is_not_nil (get-buf-command bufnr :Foo))
+        (assert.has_no_error #(vim.api.nvim_buf_del_user_command bufnr :Foo)))))
+  (it "can set callback function with quoted symbol"
+    (fn []
+      (command! :Foo `default-callback)
+      ;; Note: command.definition should be empty string if callback is
+      ;; function without `desc` key.
+      (assert.is_same "" (get-command-definition :Foo))))
+  (it "can set callback function with quoted multi-symbol"
+    (fn []
+      (let [desc :multi.sym]
+        (command! :Foo `default.multi.sym {: desc})
+        (assert.is_same desc (get-command-definition :Foo)))))
+  (it "can set quoted list result to callback"
+    (fn []
+      (let [desc :list]
+        (command! :Foo `(default-callback :foo :bar) {: desc})
+        (assert.is_same (default-callback) (get-command-definition :Foo)))))
+  (it "which sets callback `vim.fn.Test will not be overridden by `desc` key"
+    ;; Note: The reason is probably vim.fn.Test is not a Lua function but
+    ;; a Vim one.
+    (fn []
+      (let [desc :Test]
+        (command! :Foo `vim.fn.Test)
+        (assert.is_same "" (get-command-definition :Foo))
+        (assert.is_not_same desc (get-command-definition :Foo)))))
+  (it "sets callback via macro with quote"
+    (fn []
+      (command! :Foo `(macro-callback))
+      ;; TODO: Check if callback is set.
+      (assert.is_not_nil (get-command :Foo))))
+  (it "set command in macro with no args"
+    (fn []
+      (command! :Foo (macro-command))
+      (assert.is_same :macro-command (get-command-definition :Foo))))
+  (it "set command in macro with some args"
+    (fn []
+      (command! :Foo (macro-command :foo :bar))
+      (assert.is_same :macro-command (get-command-definition :Foo))))
+  (describe :extra-opts
+    (it "can be either first arg or second arg"
       (fn []
-        (assert.is_nil (get-command :Foo))
-        (command! :Foo :Bar)
-        (assert.is_not_nil (get-command :Foo))))
-    (it "defines local user command for current buffer with `<buffer>` attr"
+        (assert.has_no_error #(command! [:bang] :Foo :Bar))
+        (assert.has_no_error #(command! :Foo [:bang] :Bar)))))
+  (describe :api-opts
+    (it "gives priority api-opts over extra-opts"
       (fn []
-        (assert.is_nil (get-buf-command 0 :Foo))
-        (command! [:<buffer>] :Foo :Bar)
-        (assert.is_not_nil (get-buf-command 0 :Foo))))
-    (it "defines local user command with buffer number"
-      (fn []
-        (let [bufnr (vim.api.nvim_get_current_buf)]
-          (assert.is_nil (get-buf-command bufnr :Foo))
-          (vim.cmd.new)
-          (vim.cmd.only)
-          (command! :Foo [:buffer bufnr] :Bar)
-          (assert.is_not_nil (get-buf-command bufnr :Foo))
-          (assert.has_no_error #(vim.api.nvim_buf_del_user_command bufnr :Foo)))))
-    (it "can set callback function with quoted symbol"
-      (fn []
-        (command! :Foo `default-callback)
-        ;; Note: command.definition should be empty string if callback is
-        ;; function without `desc` key.
-        (assert.is_same "" (get-command-definition :Foo))))
-    (it "can set callback function with quoted multi-symbol"
-      (fn []
-        (let [desc :multi.sym]
-          (command! :Foo `default.multi.sym {: desc})
-          (assert.is_same desc (get-command-definition :Foo)))))
-    (it "can set quoted list result to callback"
-      (fn []
-        (let [desc :list]
-          (command! :Foo `(default-callback :foo :bar) {: desc})
-          (assert.is_same (default-callback) (get-command-definition :Foo)))))
-    (it "which sets callback `vim.fn.Test will not be overridden by `desc` key"
-      ;; Note: The reason is probably vim.fn.Test is not a Lua function but
-      ;; a Vim one.
-      (fn []
-        (let [desc :Test]
-          (command! :Foo `vim.fn.Test)
-          (assert.is_same "" (get-command-definition :Foo))
-          (assert.is_not_same desc (get-command-definition :Foo)))))
-    (it "sets callback via macro with quote"
-      (fn []
-        (command! :Foo `(macro-callback))
-        ;; TODO: Check if callback is set.
-        (assert.is_not_nil (get-command :Foo))))
-    (it "set command in macro with no args"
-      (fn []
-        (command! :Foo (macro-command))
-        (assert.is_same :macro-command (get-command-definition :Foo))))
-    (it "set command in macro with some args"
-      (fn []
-        (command! :Foo (macro-command :foo :bar))
-        (assert.is_same :macro-command (get-command-definition :Foo))))
-    (describe :extra-opts
-      (fn []
-        (it "can be either first arg or second arg"
-          (fn []
-            (assert.has_no_error #(command! [:bang] :Foo :Bar))
-            (assert.has_no_error #(command! :Foo [:bang] :Bar))))))
-    (describe :api-opts
-      (fn []
-        (it "gives priority api-opts over extra-opts"
-          (fn []
-            (command! :Foo [:bar :bang] :FooBar)
-            (assert.is_true (-> (get-command :Foo) (. :bang)))
-            (assert.is_true (-> (get-command :Foo) (. :bar)))
-            (command! :Bar [:bar :bang] :FooBar {:bar false})
-            (assert.is_false (-> (get-command :Bar) (. :bar)))
-            (let [tbl-opts {:bar false}
-                  fn-opts #{:bang false}]
-              (command! :Baz [:bar :bang] :FooBar tbl-opts)
-              (command! :Qux [:bar :bang] :FooBar (fn-opts))
-              (let [cmd-baz (get-command :Baz)
-                    cmd-qux (get-command :Qux)]
-                (assert.is_false cmd-baz.bar)
-                (assert.is_true cmd-baz.bang)
-                (assert.is_true cmd-qux.bar)
-                (assert.is_false cmd-qux.bang)))))))))
+        (command! :Foo [:bar :bang] :FooBar)
+        (assert.is_true (-> (get-command :Foo) (. :bang)))
+        (assert.is_true (-> (get-command :Foo) (. :bar)))
+        (command! :Bar [:bar :bang] :FooBar {:bar false})
+        (assert.is_false (-> (get-command :Bar) (. :bar)))
+        (let [tbl-opts {:bar false}
+              fn-opts #{:bang false}]
+          (command! :Baz [:bar :bang] :FooBar tbl-opts)
+          (command! :Qux [:bar :bang] :FooBar (fn-opts))
+          (let [cmd-baz (get-command :Baz)
+                cmd-qux (get-command :Qux)]
+            (assert.is_false cmd-baz.bar)
+            (assert.is_true cmd-baz.bang)
+            (assert.is_true cmd-qux.bar)
+            (assert.is_false cmd-qux.bang)))))))

--- a/tests/spec/command_spec.fnl
+++ b/tests/spec/command_spec.fnl
@@ -1,4 +1,4 @@
-(import-macros {: describe} :_busted_macros)
+(import-macros {: describe : it} :_busted_macros)
 (import-macros {: command!} :nvim-laurel.macros)
 
 (macro macro-callback []
@@ -29,81 +29,69 @@
                  (pcall vim.api.nvim_buf_del_user_command 0 :Foo)
                  (assert.is_nil (get-command :Foo))))
   (it "defines user command"
-    (fn []
-      (assert.is_nil (get-command :Foo))
-      (command! :Foo :Bar)
-      (assert.is_not_nil (get-command :Foo))))
+    (assert.is_nil (get-command :Foo))
+    (command! :Foo :Bar)
+    (assert.is_not_nil (get-command :Foo)))
   (it "defines local user command for current buffer with `<buffer>` attr"
-    (fn []
-      (assert.is_nil (get-buf-command 0 :Foo))
-      (command! [:<buffer>] :Foo :Bar)
-      (assert.is_not_nil (get-buf-command 0 :Foo))))
+    (assert.is_nil (get-buf-command 0 :Foo))
+    (command! [:<buffer>] :Foo :Bar)
+    (assert.is_not_nil (get-buf-command 0 :Foo)))
   (it "defines local user command with buffer number"
-    (fn []
-      (let [bufnr (vim.api.nvim_get_current_buf)]
-        (assert.is_nil (get-buf-command bufnr :Foo))
-        (vim.cmd.new)
-        (vim.cmd.only)
-        (command! :Foo [:buffer bufnr] :Bar)
-        (assert.is_not_nil (get-buf-command bufnr :Foo))
-        (assert.has_no_error #(vim.api.nvim_buf_del_user_command bufnr :Foo)))))
+    (let [bufnr (vim.api.nvim_get_current_buf)]
+      (assert.is_nil (get-buf-command bufnr :Foo))
+      (vim.cmd.new)
+      (vim.cmd.only)
+      (command! :Foo [:buffer bufnr] :Bar)
+      (assert.is_not_nil (get-buf-command bufnr :Foo))
+      (assert.has_no_error #(vim.api.nvim_buf_del_user_command bufnr :Foo))))
   (it "can set callback function with quoted symbol"
-    (fn []
-      (command! :Foo `default-callback)
-      ;; Note: command.definition should be empty string if callback is
-      ;; function without `desc` key.
-      (assert.is_same "" (get-command-definition :Foo))))
+    (command! :Foo `default-callback)
+    ;; Note: command.definition should be empty string if callback is
+    ;; function without `desc` key.
+    (assert.is_same "" (get-command-definition :Foo)))
   (it "can set callback function with quoted multi-symbol"
-    (fn []
-      (let [desc :multi.sym]
-        (command! :Foo `default.multi.sym {: desc})
-        (assert.is_same desc (get-command-definition :Foo)))))
+    (let [desc :multi.sym]
+      (command! :Foo `default.multi.sym {: desc})
+      (assert.is_same desc (get-command-definition :Foo))))
   (it "can set quoted list result to callback"
-    (fn []
-      (let [desc :list]
-        (command! :Foo `(default-callback :foo :bar) {: desc})
-        (assert.is_same (default-callback) (get-command-definition :Foo)))))
+    (let [desc :list]
+      (command! :Foo `(default-callback :foo :bar) {: desc})
+      (assert.is_same (default-callback) (get-command-definition :Foo))))
   (it "which sets callback `vim.fn.Test will not be overridden by `desc` key"
     ;; Note: The reason is probably vim.fn.Test is not a Lua function but
     ;; a Vim one.
-    (fn []
-      (let [desc :Test]
-        (command! :Foo `vim.fn.Test)
-        (assert.is_same "" (get-command-definition :Foo))
-        (assert.is_not_same desc (get-command-definition :Foo)))))
+    (let [desc :Test]
+      (command! :Foo `vim.fn.Test)
+      (assert.is_same "" (get-command-definition :Foo))
+      (assert.is_not_same desc (get-command-definition :Foo))))
   (it "sets callback via macro with quote"
-    (fn []
-      (command! :Foo `(macro-callback))
-      ;; TODO: Check if callback is set.
-      (assert.is_not_nil (get-command :Foo))))
+    (command! :Foo `(macro-callback))
+    ;; TODO: Check if callback is set.
+    (assert.is_not_nil (get-command :Foo)))
   (it "set command in macro with no args"
-    (fn []
-      (command! :Foo (macro-command))
-      (assert.is_same :macro-command (get-command-definition :Foo))))
+    (command! :Foo (macro-command))
+    (assert.is_same :macro-command (get-command-definition :Foo)))
   (it "set command in macro with some args"
-    (fn []
-      (command! :Foo (macro-command :foo :bar))
-      (assert.is_same :macro-command (get-command-definition :Foo))))
+    (command! :Foo (macro-command :foo :bar))
+    (assert.is_same :macro-command (get-command-definition :Foo)))
   (describe :extra-opts
     (it "can be either first arg or second arg"
-      (fn []
-        (assert.has_no_error #(command! [:bang] :Foo :Bar))
-        (assert.has_no_error #(command! :Foo [:bang] :Bar)))))
+      (assert.has_no_error #(command! [:bang] :Foo :Bar))
+      (assert.has_no_error #(command! :Foo [:bang] :Bar))))
   (describe :api-opts
     (it "gives priority api-opts over extra-opts"
-      (fn []
-        (command! :Foo [:bar :bang] :FooBar)
-        (assert.is_true (-> (get-command :Foo) (. :bang)))
-        (assert.is_true (-> (get-command :Foo) (. :bar)))
-        (command! :Bar [:bar :bang] :FooBar {:bar false})
-        (assert.is_false (-> (get-command :Bar) (. :bar)))
-        (let [tbl-opts {:bar false}
-              fn-opts #{:bang false}]
-          (command! :Baz [:bar :bang] :FooBar tbl-opts)
-          (command! :Qux [:bar :bang] :FooBar (fn-opts))
-          (let [cmd-baz (get-command :Baz)
-                cmd-qux (get-command :Qux)]
-            (assert.is_false cmd-baz.bar)
-            (assert.is_true cmd-baz.bang)
-            (assert.is_true cmd-qux.bar)
-            (assert.is_false cmd-qux.bang)))))))
+      (command! :Foo [:bar :bang] :FooBar)
+      (assert.is_true (-> (get-command :Foo) (. :bang)))
+      (assert.is_true (-> (get-command :Foo) (. :bar)))
+      (command! :Bar [:bar :bang] :FooBar {:bar false})
+      (assert.is_false (-> (get-command :Bar) (. :bar)))
+      (let [tbl-opts {:bar false}
+            fn-opts #{:bang false}]
+        (command! :Baz [:bar :bang] :FooBar tbl-opts)
+        (command! :Qux [:bar :bang] :FooBar (fn-opts))
+        (let [cmd-baz (get-command :Baz)
+              cmd-qux (get-command :Qux)]
+          (assert.is_false cmd-baz.bar)
+          (assert.is_true cmd-baz.bang)
+          (assert.is_true cmd-qux.bar)
+          (assert.is_false cmd-qux.bang))))))

--- a/tests/spec/highlight_spec.fnl
+++ b/tests/spec/highlight_spec.fnl
@@ -1,3 +1,4 @@
+(import-macros {: describe} :_busted_macros)
 (import-macros {: highlight!} :nvim-laurel.macros)
 
 (macro get-hl-of-rgb-color [name]
@@ -35,135 +36,131 @@
         (+ (* 16 decimal) (. hex-map m))))))
 
 (describe :highlight!
-  (fn []
+  (it "can define hl-group with color name"
+    (fn []
+      (highlight! :Foo {:fg :Red :bg :Black :bold true})
+      (highlight! :Bar {:ctermfg :Red :ctermbg :Black :bold true})
+      (highlight! :Baz {:fg :Red
+                        :bg :Black
+                        :bold true
+                        :ctermfg :Red
+                        :ctermbg :Black})))
+  (it "can define hl-group with 256-color code"
+    (fn []
+      (highlight! :Foo {:ctermfg 0 :ctermbg 255 :bold true})
+      (highlight! :Bar {:fg 0 :bg 255 :bold true :ctermfg 0 :ctermbg 255})
+      (assert.is_same {:foreground 0 :background 255 :bold true}
+                      (get-hl-of-256-color :Foo))
+      (assert.is_same {:foreground 0 :background 255 :bold true}
+                      (get-hl-of-256-color :Bar))))
+  (it "for gui can define hl-group with color code"
+    (fn []
+      (highlight! :FooBar {:fg "#000000" :bg "#FFFFFF" :bold true})
+      (assert.is_same {:foreground (hex->decimal "#000000")
+                       :background (hex->decimal "#FFFFFF")
+                       :bold true}
+                      (get-hl-of-rgb-color :FooBar))))
+  (it "can link to another hl-group"
+    (fn []
+      (highlight! :Foo {:ctermfg 0 :ctermbg 255 :bold true})
+      (highlight! :Bar {:link :Foo})
+      (assert.is_same {:foreground 0 :background 255 :bold true}
+                      (get-hl-of-256-color :Bar))))
+  (describe "with its value in bare-kv-table"
+    (it "can set fg/bg in cterm table instead of ctermfg/ctermbg"
+      (fn []
+        (highlight! :FooBar {:cterm {:fg 0 :bg 255 :bold true}})
+        (assert.is_same {:foreground 0 :background 255 :bold true}
+                        (get-hl-of-256-color :FooBar)))))
+  (describe "whose kv-table value in symbol"
     (it "can define hl-group with color name"
       (fn []
-        (highlight! :Foo {:fg :Red :bg :Black :bold true})
-        (highlight! :Bar {:ctermfg :Red :ctermbg :Black :bold true})
-        (highlight! :Baz {:fg :Red
-                          :bg :Black
-                          :bold true
-                          :ctermfg :Red
-                          :ctermbg :Black})))
+        (let [foo {:fg :Red :bg :Black :bold true}
+              bar {:ctermfg :Red :ctermbg :Black :bold true}
+              baz {:fg :Red
+                   :bg :Black
+                   :bold true
+                   :ctermfg :Red
+                   :ctermbg :Black}]
+          (highlight! :Foo foo)
+          (highlight! :Bar bar)
+          (highlight! :Baz baz))))
     (it "can define hl-group with 256-color code"
       (fn []
-        (highlight! :Foo {:ctermfg 0 :ctermbg 255 :bold true})
-        (highlight! :Bar {:fg 0 :bg 255 :bold true :ctermfg 0 :ctermbg 255})
-        (assert.is_same {:foreground 0 :background 255 :bold true}
-                        (get-hl-of-256-color :Foo))
-        (assert.is_same {:foreground 0 :background 255 :bold true}
-                        (get-hl-of-256-color :Bar))))
+        (let [foo {:ctermfg 0 :ctermbg 255 :bold true}
+              bar {:fg 0 :bg 255 :bold true :ctermfg 0 :ctermbg 255}]
+          (highlight! :Foo foo)
+          (highlight! :Bar bar)
+          (assert.is_same {:foreground 0 :background 255 :bold true}
+                          (get-hl-of-256-color :Foo))
+          (assert.is_same {:foreground 0 :background 255 :bold true}
+                          (get-hl-of-256-color :Bar)))))
     (it "for gui can define hl-group with color code"
       (fn []
-        (highlight! :FooBar {:fg "#000000" :bg "#FFFFFF" :bold true})
-        (assert.is_same {:foreground (hex->decimal "#000000")
-                         :background (hex->decimal "#FFFFFF")
-                         :bold true}
-                        (get-hl-of-rgb-color :FooBar))))
+        (let [foobar {:fg "#000000" :bg "#FFFFFF" :bold true}]
+          (highlight! :FooBar foobar)
+          (assert.is_same {:foreground (hex->decimal "#000000")
+                           :background (hex->decimal "#FFFFFF")
+                           :bold true}
+                          (get-hl-of-rgb-color :FooBar)))))
     (it "can link to another hl-group"
       (fn []
-        (highlight! :Foo {:ctermfg 0 :ctermbg 255 :bold true})
-        (highlight! :Bar {:link :Foo})
+        (let [foo {:ctermfg 0 :ctermbg 255 :bold true}
+              bar {:link :Foo}]
+          (highlight! :Foo foo)
+          (highlight! :Bar bar))
         (assert.is_same {:foreground 0 :background 255 :bold true}
                         (get-hl-of-256-color :Bar))))
     (describe "with its value in bare-kv-table"
+      (it "cannot set fg/bg in cterm table instead of ctermfg/ctermbg"
+        (fn []
+          (let [foobar {:cterm {:fg 0 :bg 255 :bold true}}]
+            ;; Note: fg/bg in `cterm` table is invalid; instead, use
+            ;; ctermfg/ctermbg respectively.
+            (assert.has_error #(highlight! :FooBar foobar)))))))
+  (describe "whose kv-table value in list"
+    (it "can define hl-group with color name"
       (fn []
-        (it "can set fg/bg in cterm table instead of ctermfg/ctermbg"
-          (fn []
-            (highlight! :FooBar {:cterm {:fg 0 :bg 255 :bold true}})
-            (assert.is_same {:foreground 0 :background 255 :bold true}
-                            (get-hl-of-256-color :FooBar))))))
-    (describe "whose kv-table value in symbol"
-      (it "can define hl-group with color name"
-        (fn []
-          (let [foo {:fg :Red :bg :Black :bold true}
-                bar {:ctermfg :Red :ctermbg :Black :bold true}
-                baz {:fg :Red
-                     :bg :Black
-                     :bold true
-                     :ctermfg :Red
-                     :ctermbg :Black}]
-            (highlight! :Foo foo)
-            (highlight! :Bar bar)
-            (highlight! :Baz baz))))
-      (it "can define hl-group with 256-color code"
-        (fn []
-          (let [foo {:ctermfg 0 :ctermbg 255 :bold true}
-                bar {:fg 0 :bg 255 :bold true :ctermfg 0 :ctermbg 255}]
-            (highlight! :Foo foo)
-            (highlight! :Bar bar)
-            (assert.is_same {:foreground 0 :background 255 :bold true}
-                            (get-hl-of-256-color :Foo))
-            (assert.is_same {:foreground 0 :background 255 :bold true}
-                            (get-hl-of-256-color :Bar)))))
-      (it "for gui can define hl-group with color code"
-        (fn []
-          (let [foobar {:fg "#000000" :bg "#FFFFFF" :bold true}]
-            (highlight! :FooBar foobar)
-            (assert.is_same {:foreground (hex->decimal "#000000")
-                             :background (hex->decimal "#FFFFFF")
-                             :bold true}
-                            (get-hl-of-rgb-color :FooBar)))))
-      (it "can link to another hl-group"
-        (fn []
-          (let [foo {:ctermfg 0 :ctermbg 255 :bold true}
-                bar {:link :Foo}]
-            (highlight! :Foo foo)
-            (highlight! :Bar bar))
+        (let [foo #{:fg :Red :bg :Black :bold true}
+              bar #{:ctermfg :Red :ctermbg :Black :bold true}
+              baz #{:fg :Red
+                    :bg :Black
+                    :bold true
+                    :ctermfg :Red
+                    :ctermbg :Black}]
+          (highlight! :Foo (foo))
+          (highlight! :Bar (bar))
+          (highlight! :Baz (baz)))))
+    (it "can define hl-group with 256-color code"
+      (fn []
+        (let [foo #{:ctermfg 0 :ctermbg 255 :bold true}
+              bar #{:fg 0 :bg 255 :bold true :ctermfg 0 :ctermbg 255}]
+          (highlight! :Foo (foo))
+          (highlight! :Bar (bar))
           (assert.is_same {:foreground 0 :background 255 :bold true}
-                          (get-hl-of-256-color :Bar))))
-      (describe "with its value in bare-kv-table"
-        (fn []
-          (it "cannot set fg/bg in cterm table instead of ctermfg/ctermbg"
-            (fn []
-              (let [foobar {:cterm {:fg 0 :bg 255 :bold true}}]
-                ;; Note: fg/bg in `cterm` table is invalid; instead, use
-                ;; ctermfg/ctermbg respectively.
-                (assert.has_error #(highlight! :FooBar foobar))))))))
-    (describe "whose kv-table value in list"
-      (it "can define hl-group with color name"
-        (fn []
-          (let [foo #{:fg :Red :bg :Black :bold true}
-                bar #{:ctermfg :Red :ctermbg :Black :bold true}
-                baz #{:fg :Red
-                      :bg :Black
-                      :bold true
-                      :ctermfg :Red
-                      :ctermbg :Black}]
-            (highlight! :Foo (foo))
-            (highlight! :Bar (bar))
-            (highlight! :Baz (baz)))))
-      (it "can define hl-group with 256-color code"
-        (fn []
-          (let [foo #{:ctermfg 0 :ctermbg 255 :bold true}
-                bar #{:fg 0 :bg 255 :bold true :ctermfg 0 :ctermbg 255}]
-            (highlight! :Foo (foo))
-            (highlight! :Bar (bar))
-            (assert.is_same {:foreground 0 :background 255 :bold true}
-                            (get-hl-of-256-color :Foo))
-            (assert.is_same {:foreground 0 :background 255 :bold true}
-                            (get-hl-of-256-color :Bar)))))
-      (it "for gui can define hl-group with color code"
-        (fn []
-          (let [foobar #{:fg "#000000" :bg "#FFFFFF" :bold true}]
-            (highlight! :FooBar (foobar))
-            (assert.is_same {:foreground (hex->decimal "#000000")
-                             :background (hex->decimal "#FFFFFF")
-                             :bold true}
-                            (get-hl-of-rgb-color :FooBar)))))
-      (it "can link to another hl-group"
-        (fn []
-          (let [foo #{:ctermfg 0 :ctermbg 255 :bold true}
-                bar #{:link :Foo}]
-            (highlight! :Foo (foo))
-            (highlight! :Bar (bar)))
+                          (get-hl-of-256-color :Foo))
           (assert.is_same {:foreground 0 :background 255 :bold true}
-                          (get-hl-of-256-color :Bar))))
-      (describe "with its value in bare-kv-table"
+                          (get-hl-of-256-color :Bar)))))
+    (it "for gui can define hl-group with color code"
+      (fn []
+        (let [foobar #{:fg "#000000" :bg "#FFFFFF" :bold true}]
+          (highlight! :FooBar (foobar))
+          (assert.is_same {:foreground (hex->decimal "#000000")
+                           :background (hex->decimal "#FFFFFF")
+                           :bold true}
+                          (get-hl-of-rgb-color :FooBar)))))
+    (it "can link to another hl-group"
+      (fn []
+        (let [foo #{:ctermfg 0 :ctermbg 255 :bold true}
+              bar #{:link :Foo}]
+          (highlight! :Foo (foo))
+          (highlight! :Bar (bar)))
+        (assert.is_same {:foreground 0 :background 255 :bold true}
+                        (get-hl-of-256-color :Bar))))
+    (describe "with its value in bare-kv-table"
+      (it "cannot set fg/bg in cterm table instead of ctermfg/ctermbg"
         (fn []
-          (it "cannot set fg/bg in cterm table instead of ctermfg/ctermbg"
-            (fn []
-              (let [foobar #{:cterm {:fg 0 :bg 255 :bold true}}]
-                ;; Note: fg/bg in `cterm` table is invalid; instead, use
-                ;; ctermfg/ctermbg respectively.
-                (assert.has_error #(highlight! :FooBar (foobar)))))))))))
+          (let [foobar #{:cterm {:fg 0 :bg 255 :bold true}}]
+            ;; Note: fg/bg in `cterm` table is invalid; instead, use
+            ;; ctermfg/ctermbg respectively.
+            (assert.has_error #(highlight! :FooBar (foobar)))))))))

--- a/tests/spec/highlight_spec.fnl
+++ b/tests/spec/highlight_spec.fnl
@@ -1,4 +1,4 @@
-(import-macros {: describe} :_busted_macros)
+(import-macros {: describe : it} :_busted_macros)
 (import-macros {: highlight!} :nvim-laurel.macros)
 
 (macro get-hl-of-rgb-color [name]
@@ -37,130 +37,107 @@
 
 (describe :highlight!
   (it "can define hl-group with color name"
-    (fn []
-      (highlight! :Foo {:fg :Red :bg :Black :bold true})
-      (highlight! :Bar {:ctermfg :Red :ctermbg :Black :bold true})
-      (highlight! :Baz {:fg :Red
-                        :bg :Black
-                        :bold true
-                        :ctermfg :Red
-                        :ctermbg :Black})))
+    (highlight! :Foo {:fg :Red :bg :Black :bold true})
+    (highlight! :Bar {:ctermfg :Red :ctermbg :Black :bold true})
+    (highlight! :Baz {:fg :Red
+                      :bg :Black
+                      :bold true
+                      :ctermfg :Red
+                      :ctermbg :Black}))
   (it "can define hl-group with 256-color code"
-    (fn []
-      (highlight! :Foo {:ctermfg 0 :ctermbg 255 :bold true})
-      (highlight! :Bar {:fg 0 :bg 255 :bold true :ctermfg 0 :ctermbg 255})
-      (assert.is_same {:foreground 0 :background 255 :bold true}
-                      (get-hl-of-256-color :Foo))
-      (assert.is_same {:foreground 0 :background 255 :bold true}
-                      (get-hl-of-256-color :Bar))))
+    (highlight! :Foo {:ctermfg 0 :ctermbg 255 :bold true})
+    (highlight! :Bar {:fg 0 :bg 255 :bold true :ctermfg 0 :ctermbg 255})
+    (assert.is_same {:foreground 0 :background 255 :bold true}
+                    (get-hl-of-256-color :Foo))
+    (assert.is_same {:foreground 0 :background 255 :bold true}
+                    (get-hl-of-256-color :Bar)))
   (it "for gui can define hl-group with color code"
-    (fn []
-      (highlight! :FooBar {:fg "#000000" :bg "#FFFFFF" :bold true})
-      (assert.is_same {:foreground (hex->decimal "#000000")
-                       :background (hex->decimal "#FFFFFF")
-                       :bold true}
-                      (get-hl-of-rgb-color :FooBar))))
+    (highlight! :FooBar {:fg "#000000" :bg "#FFFFFF" :bold true})
+    (assert.is_same {:foreground (hex->decimal "#000000")
+                     :background (hex->decimal "#FFFFFF")
+                     :bold true}
+                    (get-hl-of-rgb-color :FooBar)))
   (it "can link to another hl-group"
-    (fn []
-      (highlight! :Foo {:ctermfg 0 :ctermbg 255 :bold true})
-      (highlight! :Bar {:link :Foo})
-      (assert.is_same {:foreground 0 :background 255 :bold true}
-                      (get-hl-of-256-color :Bar))))
+    (highlight! :Foo {:ctermfg 0 :ctermbg 255 :bold true})
+    (highlight! :Bar {:link :Foo})
+    (assert.is_same {:foreground 0 :background 255 :bold true}
+                    (get-hl-of-256-color :Bar)))
   (describe "with its value in bare-kv-table"
     (it "can set fg/bg in cterm table instead of ctermfg/ctermbg"
-      (fn []
-        (highlight! :FooBar {:cterm {:fg 0 :bg 255 :bold true}})
-        (assert.is_same {:foreground 0 :background 255 :bold true}
-                        (get-hl-of-256-color :FooBar)))))
+      (highlight! :FooBar {:cterm {:fg 0 :bg 255 :bold true}})
+      (assert.is_same {:foreground 0 :background 255 :bold true}
+                      (get-hl-of-256-color :FooBar))))
   (describe "whose kv-table value in symbol"
     (it "can define hl-group with color name"
-      (fn []
-        (let [foo {:fg :Red :bg :Black :bold true}
-              bar {:ctermfg :Red :ctermbg :Black :bold true}
-              baz {:fg :Red
-                   :bg :Black
-                   :bold true
-                   :ctermfg :Red
-                   :ctermbg :Black}]
-          (highlight! :Foo foo)
-          (highlight! :Bar bar)
-          (highlight! :Baz baz))))
+      (let [foo {:fg :Red :bg :Black :bold true}
+            bar {:ctermfg :Red :ctermbg :Black :bold true}
+            baz {:fg :Red :bg :Black :bold true :ctermfg :Red :ctermbg :Black}]
+        (highlight! :Foo foo)
+        (highlight! :Bar bar)
+        (highlight! :Baz baz)))
     (it "can define hl-group with 256-color code"
-      (fn []
-        (let [foo {:ctermfg 0 :ctermbg 255 :bold true}
-              bar {:fg 0 :bg 255 :bold true :ctermfg 0 :ctermbg 255}]
-          (highlight! :Foo foo)
-          (highlight! :Bar bar)
-          (assert.is_same {:foreground 0 :background 255 :bold true}
-                          (get-hl-of-256-color :Foo))
-          (assert.is_same {:foreground 0 :background 255 :bold true}
-                          (get-hl-of-256-color :Bar)))))
-    (it "for gui can define hl-group with color code"
-      (fn []
-        (let [foobar {:fg "#000000" :bg "#FFFFFF" :bold true}]
-          (highlight! :FooBar foobar)
-          (assert.is_same {:foreground (hex->decimal "#000000")
-                           :background (hex->decimal "#FFFFFF")
-                           :bold true}
-                          (get-hl-of-rgb-color :FooBar)))))
-    (it "can link to another hl-group"
-      (fn []
-        (let [foo {:ctermfg 0 :ctermbg 255 :bold true}
-              bar {:link :Foo}]
-          (highlight! :Foo foo)
-          (highlight! :Bar bar))
+      (let [foo {:ctermfg 0 :ctermbg 255 :bold true}
+            bar {:fg 0 :bg 255 :bold true :ctermfg 0 :ctermbg 255}]
+        (highlight! :Foo foo)
+        (highlight! :Bar bar)
+        (assert.is_same {:foreground 0 :background 255 :bold true}
+                        (get-hl-of-256-color :Foo))
         (assert.is_same {:foreground 0 :background 255 :bold true}
                         (get-hl-of-256-color :Bar))))
+    (it "for gui can define hl-group with color code"
+      (let [foobar {:fg "#000000" :bg "#FFFFFF" :bold true}]
+        (highlight! :FooBar foobar)
+        (assert.is_same {:foreground (hex->decimal "#000000")
+                         :background (hex->decimal "#FFFFFF")
+                         :bold true}
+                        (get-hl-of-rgb-color :FooBar))))
+    (it "can link to another hl-group"
+      (let [foo {:ctermfg 0 :ctermbg 255 :bold true}
+            bar {:link :Foo}]
+        (highlight! :Foo foo)
+        (highlight! :Bar bar))
+      (assert.is_same {:foreground 0 :background 255 :bold true}
+                      (get-hl-of-256-color :Bar)))
     (describe "with its value in bare-kv-table"
       (it "cannot set fg/bg in cterm table instead of ctermfg/ctermbg"
-        (fn []
-          (let [foobar {:cterm {:fg 0 :bg 255 :bold true}}]
-            ;; Note: fg/bg in `cterm` table is invalid; instead, use
-            ;; ctermfg/ctermbg respectively.
-            (assert.has_error #(highlight! :FooBar foobar)))))))
+        (let [foobar {:cterm {:fg 0 :bg 255 :bold true}}]
+          ;; Note: fg/bg in `cterm` table is invalid; instead, use
+          ;; ctermfg/ctermbg respectively.
+          (assert.has_error #(highlight! :FooBar foobar))))))
   (describe "whose kv-table value in list"
     (it "can define hl-group with color name"
-      (fn []
-        (let [foo #{:fg :Red :bg :Black :bold true}
-              bar #{:ctermfg :Red :ctermbg :Black :bold true}
-              baz #{:fg :Red
-                    :bg :Black
-                    :bold true
-                    :ctermfg :Red
-                    :ctermbg :Black}]
-          (highlight! :Foo (foo))
-          (highlight! :Bar (bar))
-          (highlight! :Baz (baz)))))
+      (let [foo #{:fg :Red :bg :Black :bold true}
+            bar #{:ctermfg :Red :ctermbg :Black :bold true}
+            baz #{:fg :Red :bg :Black :bold true :ctermfg :Red :ctermbg :Black}]
+        (highlight! :Foo (foo))
+        (highlight! :Bar (bar))
+        (highlight! :Baz (baz))))
     (it "can define hl-group with 256-color code"
-      (fn []
-        (let [foo #{:ctermfg 0 :ctermbg 255 :bold true}
-              bar #{:fg 0 :bg 255 :bold true :ctermfg 0 :ctermbg 255}]
-          (highlight! :Foo (foo))
-          (highlight! :Bar (bar))
-          (assert.is_same {:foreground 0 :background 255 :bold true}
-                          (get-hl-of-256-color :Foo))
-          (assert.is_same {:foreground 0 :background 255 :bold true}
-                          (get-hl-of-256-color :Bar)))))
-    (it "for gui can define hl-group with color code"
-      (fn []
-        (let [foobar #{:fg "#000000" :bg "#FFFFFF" :bold true}]
-          (highlight! :FooBar (foobar))
-          (assert.is_same {:foreground (hex->decimal "#000000")
-                           :background (hex->decimal "#FFFFFF")
-                           :bold true}
-                          (get-hl-of-rgb-color :FooBar)))))
-    (it "can link to another hl-group"
-      (fn []
-        (let [foo #{:ctermfg 0 :ctermbg 255 :bold true}
-              bar #{:link :Foo}]
-          (highlight! :Foo (foo))
-          (highlight! :Bar (bar)))
+      (let [foo #{:ctermfg 0 :ctermbg 255 :bold true}
+            bar #{:fg 0 :bg 255 :bold true :ctermfg 0 :ctermbg 255}]
+        (highlight! :Foo (foo))
+        (highlight! :Bar (bar))
+        (assert.is_same {:foreground 0 :background 255 :bold true}
+                        (get-hl-of-256-color :Foo))
         (assert.is_same {:foreground 0 :background 255 :bold true}
                         (get-hl-of-256-color :Bar))))
+    (it "for gui can define hl-group with color code"
+      (let [foobar #{:fg "#000000" :bg "#FFFFFF" :bold true}]
+        (highlight! :FooBar (foobar))
+        (assert.is_same {:foreground (hex->decimal "#000000")
+                         :background (hex->decimal "#FFFFFF")
+                         :bold true}
+                        (get-hl-of-rgb-color :FooBar))))
+    (it "can link to another hl-group"
+      (let [foo #{:ctermfg 0 :ctermbg 255 :bold true}
+            bar #{:link :Foo}]
+        (highlight! :Foo (foo))
+        (highlight! :Bar (bar)))
+      (assert.is_same {:foreground 0 :background 255 :bold true}
+                      (get-hl-of-256-color :Bar)))
     (describe "with its value in bare-kv-table"
       (it "cannot set fg/bg in cterm table instead of ctermfg/ctermbg"
-        (fn []
-          (let [foobar #{:cterm {:fg 0 :bg 255 :bold true}}]
-            ;; Note: fg/bg in `cterm` table is invalid; instead, use
-            ;; ctermfg/ctermbg respectively.
-            (assert.has_error #(highlight! :FooBar (foobar)))))))))
+        (let [foobar #{:cterm {:fg 0 :bg 255 :bold true}}]
+          ;; Note: fg/bg in `cterm` table is invalid; instead, use
+          ;; ctermfg/ctermbg respectively.
+          (assert.has_error #(highlight! :FooBar (foobar))))))))

--- a/tests/spec/keymap_spec.fnl
+++ b/tests/spec/keymap_spec.fnl
@@ -1,4 +1,4 @@
-(import-macros {: describe} :_busted_macros)
+(import-macros {: describe : it} :_busted_macros)
 (import-macros {: map!
                 : noremap!
                 : nnoremap!
@@ -49,240 +49,216 @@
 (lambda buf-get-callback [bufnr mode lhs]
   (?. (buf-get-mapargs bufnr mode lhs) :callback))
 
-(insulate :macros.keymap
-  (fn []
-    (setup (fn []
-             (vim.cmd "function g:Test() abort
-                       endfunction")))
-    (teardown (fn []
-                (vim.cmd "delfunction g:Test")))
-    (before_each (fn []
-                   (let [all-modes ["" "!" :l :t]]
-                     (each [_ mode (ipairs all-modes)]
-                       (pcall vim.api.nvim_del_keymap mode :lhs)
-                       (assert.is_nil (get-rhs mode :lhs))))))
-    (describe :map!
-      (it "sets callback function with quoted symbol"
-        (fn []
-          (map! :n :lhs `default-callback)
-          (assert.is_same default-callback (get-callback :n :lhs))))
-      (it "sets callback function with quoted multi-symbol"
-        #(let [desc :multi.sym]
-           (map! :n :lhs `default.multi.sym {: desc})
-           (assert.is_same default.multi.sym (get-callback :n :lhs))))
-      (it "sets callback function with quoted list"
-        #(let [desc :list]
-           (map! :n :lhs `(default-callback :foo :bar) {: desc})
-           (assert.is_same desc (. (get-mapargs :n :lhs) :desc))))
-      (it "set callback function in string for `vim.fn.Test"
-        (fn []
-          (map! :n :lhs `vim.fn.Test)
-          (assert.is_same vim.fn.Test (get-callback :n :lhs))))
-      (it "maps non-recursively by default"
-        #(let [mode :n
-               modes [:n :o :t]]
-           (map! mode :lhs :rhs)
-           (map! modes :lhs :rhs)
-           (let [{: noremap} (get-mapargs mode :lhs)]
-             (assert.is.same 1 noremap))
-           (each [_ m (ipairs modes)]
-             (let [{: noremap} (get-mapargs m :lhs)]
-               (assert.is.same 1 noremap)))))
-      (it "is also available to recursive mappings"
-        #(let [mode :n]
-           (map! :o [:remap] :lhs :rhs)
-           (map! mode [:remap] :lhs :rhs)
-           (let [{: noremap} (get-mapargs :o :lhs)]
-             (assert.is.same 0 noremap))
-           (let [{: noremap} (get-mapargs mode :lhs)]
-             (assert.is.same 0 noremap))))
-      (it "gives priority to `api-opts`"
-        #(let [mode :n
-               modes [:i :c :t]
-               api-opts {:noremap true}]
-           (map! :o :lhs :rhs api-opts)
-           (map! mode :lhs :rhs api-opts)
-           (map! modes :lhs :rhs api-opts)
-           (let [{: noremap} (get-mapargs :o :lhs)]
-             (assert.is.same 1 noremap))
-           (let [{: noremap} (get-mapargs mode :lhs)]
-             (assert.is.same 1 noremap))
-           (each [_ m (ipairs modes)]
-             (let [{: noremap} (get-mapargs m :lhs)]
-               (assert.is.same 1 noremap)))))
-      (it "sets callback via macro with quote"
-        (fn []
-          (map! :n :lhs `(macro-callback))
-          (assert.is_not_nil (get-callback :n :lhs))))
-      (it "set command in macro with no args"
-        (fn []
-          (map! :n :lhs (macro-command))
-          (assert.is_same :macro-command (get-rhs :n :lhs))))
-      (it "set command in macro with some args"
-        (fn []
-          (map! :n :lhs (macro-command :foo :bar))
-          (assert.is_same :macro-command (get-rhs :n :lhs))))
-      (it "maps multiple mode mappings with a sequence at once"
-        #(let [modes [:n :c :t]]
-           (noremap! modes :lhs :rhs)
-           (each [_ mode (ipairs modes)]
-             (assert.is.same :rhs (get-rhs mode :lhs)))))
-      (it "maps multiple mode mappings with a bare-string at once"
-        (fn []
-          (noremap! :nct :lhs :rhs)
-          (each [mode (-> :nct (: :gmatch "."))]
+(describe :macros.keymap
+  (setup (fn []
+           (vim.cmd "function g:Test()\nendfunction")))
+  (teardown (fn []
+              (vim.cmd "delfunction g:Test")))
+  (before_each (fn []
+                 (let [all-modes ["" "!" :l :t]]
+                   (each [_ mode (ipairs all-modes)]
+                     (pcall vim.api.nvim_del_keymap mode :lhs)
+                     (assert.is_nil (get-rhs mode :lhs))))))
+  (describe :map!
+    (it "sets callback function with quoted symbol"
+      (map! :n :lhs `default-callback)
+      (assert.is_same default-callback (get-callback :n :lhs)))
+    (it "sets callback function with quoted multi-symbol"
+      (let [desc :multi.sym]
+        (map! :n :lhs `default.multi.sym {: desc})
+        (assert.is_same default.multi.sym (get-callback :n :lhs))))
+    (it "sets callback function with quoted list"
+      (let [desc :list]
+        (map! :n :lhs `(default-callback :foo :bar) {: desc})
+        (assert.is_same desc (. (get-mapargs :n :lhs) :desc))))
+    (it "set callback function in string for `vim.fn.Test"
+      (map! :n :lhs `vim.fn.Test)
+      (assert.is_same vim.fn.Test (get-callback :n :lhs)))
+    (it "maps non-recursively by default"
+      (let [mode :n
+            modes [:n :o :t]]
+        (map! mode :lhs :rhs)
+        (map! modes :lhs :rhs)
+        (let [{: noremap} (get-mapargs mode :lhs)]
+          (assert.is.same 1 noremap))
+        (each [_ m (ipairs modes)]
+          (let [{: noremap} (get-mapargs m :lhs)]
+            (assert.is.same 1 noremap)))))
+    (it "is also available to recursive mappings"
+      (let [mode :n]
+        (map! :o [:remap] :lhs :rhs)
+        (map! mode [:remap] :lhs :rhs)
+        (let [{: noremap} (get-mapargs :o :lhs)]
+          (assert.is.same 0 noremap))
+        (let [{: noremap} (get-mapargs mode :lhs)]
+          (assert.is.same 0 noremap))))
+    (it "gives priority to `api-opts`"
+      (let [mode :n
+            modes [:i :c :t]
+            api-opts {:noremap true}]
+        (map! :o :lhs :rhs api-opts)
+        (map! mode :lhs :rhs api-opts)
+        (map! modes :lhs :rhs api-opts)
+        (let [{: noremap} (get-mapargs :o :lhs)]
+          (assert.is.same 1 noremap))
+        (let [{: noremap} (get-mapargs mode :lhs)]
+          (assert.is.same 1 noremap))
+        (each [_ m (ipairs modes)]
+          (let [{: noremap} (get-mapargs m :lhs)]
+            (assert.is.same 1 noremap)))))
+    (it "sets callback via macro with quote"
+      (map! :n :lhs `(macro-callback))
+      (assert.is_not_nil (get-callback :n :lhs)))
+    (it "set command in macro with no args"
+      (map! :n :lhs (macro-command))
+      (assert.is_same :macro-command (get-rhs :n :lhs)))
+    (it "set command in macro with some args"
+      (map! :n :lhs (macro-command :foo :bar))
+      (assert.is_same :macro-command (get-rhs :n :lhs)))
+    (it "maps multiple mode mappings with a sequence at once"
+      (let [modes [:n :c :t]]
+        (noremap! modes :lhs :rhs)
+        (each [_ mode (ipairs modes)]
+          (assert.is.same :rhs (get-rhs mode :lhs)))))
+    (it "maps multiple mode mappings with a bare-string at once"
+      (noremap! :nct :lhs :rhs)
+      (each [mode (-> :nct (: :gmatch "."))]
+        (assert.is.same :rhs (get-rhs mode :lhs))))
+    (it "enables `replace_keycodes` with `expr` in `extra-opts`"
+      (let [modes [:n]]
+        (map! modes [:expr] :lhs :rhs)
+        (let [{: replace_keycodes} (get-mapargs :n :lhs)]
+          (assert.is.same 1 replace_keycodes))))
+    (it "disables `replace_keycodes` with `literal` in `extra-opts`"
+      (let [modes [:n]]
+        (map! modes [:expr :literal] :lhs :rhs)
+        (let [{: replace_keycodes} (get-mapargs :n :lhs)]
+          (assert.is_nil replace_keycodes)))))
+  (describe :unmap!
+    (it "`unmap`s key"
+      (nnoremap! :lhs :rhs)
+      (assert.is.same :rhs (get-rhs :n :lhs))
+      (unmap! :n :lhs)
+      (assert.is_nil (get-rhs :n :lhs)))
+    (it "can unmap buffer local key"
+      (let [bufnr (vim.api.nvim_get_current_buf)]
+        (nnoremap! [:<buffer>] :lhs :rhs)
+        (assert.is.same :rhs (buf-get-rhs 0 :n :lhs))
+        (unmap! 0 :n :lhs)
+        (assert.is_nil (buf-get-rhs 0 :n :lhs))
+        (nnoremap! [:buffer bufnr] :lhs :rhs)
+        (assert.is.same :rhs (buf-get-rhs bufnr :n :lhs))
+        (unmap! bufnr :n :lhs)
+        (assert.is_nil (buf-get-rhs bufnr :n :lhs)))))
+  (describe :<Cmd>/<C-u>
+    (it "is set to rhs as a string"
+      (assert.has_no.errors #(nnoremap! :lhs (<Cmd> "Do something")))
+      (assert.is.same "<Cmd>Do something<CR>" (get-rhs :n :lhs))
+      (assert.has_no.errors #(nnoremap! [:<buffer>] :lhs (<C-u> "Do something")))
+      (assert.is.same ":<C-U>Do something<CR>" (buf-get-rhs 0 :n :lhs))))
+  (describe "(deprecated)"
+    (describe :noremap!
+      (it "maps lhs to rhs with `noremap` set to `true` represented by `1`"
+        (let [mode :n]
+          (noremap! mode :lhs :rhs)
+          (let [{: noremap} (get-mapargs mode :lhs)]
+            (assert.is.same 1 noremap))))
+      (it "maps multiple mode mappings with sequence at once"
+        (let [modes [:n :t :o]]
+          (noremap! modes :lhs :rhs)
+          (each [_ mode (ipairs modes)]
             (assert.is.same :rhs (get-rhs mode :lhs)))))
-      (it "enables `replace_keycodes` with `expr` in `extra-opts`"
-        #(let [modes [:n]]
-           (map! modes [:expr] :lhs :rhs)
-           (let [{: replace_keycodes} (get-mapargs :n :lhs)]
-             (assert.is.same 1 replace_keycodes))))
-      (it "disables `replace_keycodes` with `literal` in `extra-opts`"
-        #(let [modes [:n]]
-           (map! modes [:expr :literal] :lhs :rhs)
-           (let [{: replace_keycodes} (get-mapargs :n :lhs)]
-             (assert.is_nil replace_keycodes)))))
-    (describe :unmap!
-      (it "`unmap`s key"
-        (fn []
-          (nnoremap! :lhs :rhs)
-          (assert.is.same :rhs (get-rhs :n :lhs))
-          (unmap! :n :lhs)
-          (assert.is_nil (get-rhs :n :lhs))))
-      (it "can unmap buffer local key"
-        (fn []
-          (let [bufnr (vim.api.nvim_get_current_buf)]
-            (nnoremap! [:<buffer>] :lhs :rhs)
-            (assert.is.same :rhs (buf-get-rhs 0 :n :lhs))
-            (unmap! 0 :n :lhs)
-            (assert.is_nil (buf-get-rhs 0 :n :lhs))
-            (nnoremap! [:buffer bufnr] :lhs :rhs)
-            (assert.is.same :rhs (buf-get-rhs bufnr :n :lhs))
-            (unmap! bufnr :n :lhs)
-            (assert.is_nil (buf-get-rhs bufnr :n :lhs))))))
-    (describe :<Cmd>/<C-u>
-      (it "is set to rhs as a string"
-        (fn []
-          (assert.has_no.errors #(nnoremap! :lhs (<Cmd> "Do something")))
-          (assert.is.same "<Cmd>Do something<CR>" (get-rhs :n :lhs))
-          (assert.has_no.errors #(nnoremap! [:<buffer>] :lhs
-                                            (<C-u> "Do something")))
-          (assert.is.same ":<C-U>Do something<CR>" (buf-get-rhs 0 :n :lhs)))))
-    (describe "(deprecated)"
-      (describe :noremap!
-        (it "maps lhs to rhs with `noremap` set to `true` represented by `1`"
-          #(let [mode :n]
-             (noremap! mode :lhs :rhs)
-             (let [{: noremap} (get-mapargs mode :lhs)]
-               (assert.is.same 1 noremap))))
-        (it "maps multiple mode mappings with sequence at once"
-          #(let [modes [:n :t :o]]
-             (noremap! modes :lhs :rhs)
-             (each [_ mode (ipairs modes)]
-               (assert.is.same :rhs (get-rhs mode :lhs)))))
-        (it "maps recursively with `remap` key in `extra-opts`"
-          #(let [modes [:n :o :x]]
-             (noremap! modes [:remap] :lhs :rhs)
-             (each [_ m (ipairs modes)]
-               (let [{: noremap} (get-mapargs m :lhs)]
-                 (assert.is.same 0 noremap))))))
-      (describe :nnoremap!
-        (it "can include extra-opts in either first or second arg"
-          (fn []
-            (assert.has_no.errors #(nnoremap! [:nowait] :lhs :rhs))
-            (assert.has_no.errors #(nnoremap! :lhs [:nowait] :rhs))))
-        (it "maps to current buffer with `<buffer>`"
-          (fn []
-            (nnoremap! [:<buffer>] :lhs :rhs)
-            (assert.is.same :rhs (buf-get-rhs 0 :n :lhs))))
-        (it "maps to specific buffer with `buffer`"
-          (fn []
-            (let [bufnr (vim.api.nvim_get_current_buf)]
-              (refresh-buffer)
-              (nnoremap! [:buffer bufnr] :lhs :rhs)
-              (assert.is_nil (buf-get-rhs 0 :n :lhs))
-              (assert.is.same :rhs (buf-get-rhs bufnr :n :lhs)))))
-        (it "set a list which will result in string without callback"
-          (fn []
-            (nnoremap! :lhs (.. :r :h :s))
-            (nnoremap! :lhs1 (.. (<Cmd> :foobar) :<Esc>))
-            (assert.is.same :rhs (get-rhs :n :lhs))
-            (assert.is.same :<Cmd>foobar<CR><Esc> (get-rhs :n :lhs1))))
-        (it "can set Ex command in autocmds with `<command>` key"
-          (fn []
-            (nnoremap! :lhs1 [:<command>] default-rhs)
-            (nnoremap! :lhs2 [:<command>] (.. :foo :bar))
-            (assert.is.same default-rhs (get-rhs :n :lhs1))
-            (assert.is.same :foobar (get-rhs :n :lhs2))))
-        (it "can set Ex command in autocmds with `ex` key"
-          (fn []
-            (nnoremap! :lhs1 [:ex] default-rhs)
-            (nnoremap! :lhs2 [:ex] (.. :foo :bar))
-            (assert.is.same default-rhs (get-rhs :n :lhs1))
-            (assert.is.same :foobar (get-rhs :n :lhs2))))
-        (it "can set callback function in autocmds with `<callback>` key"
-          (fn []
-            (nnoremap! :lhs1 [:<callback>] default-callback)
-            ;; Note: vim.api.nvim_get_keymap cannot get vim function.
-            (nnoremap! :lhs2 [:<callback>] (new-callback (.. :foo :bar)))
-            (assert.is.same default-callback (get-callback :n :lhs1))
-            (assert.is_true (= :function (type (get-callback :n :lhs2))))))
-        (it "can set callback function in autocmds with `cb` key"
-          (fn []
-            (nnoremap! :lhs1 [:cb] default-callback)
-            (nnoremap! :lhs2 [:cb] (new-callback (.. :foo :bar)))
-            (assert.is.same default-callback (get-callback :n :lhs1))
-            (assert.is_true (= :function (type (get-callback :n :lhs2))))))
-        (it "enables `replace_keycodes` when `expr` is set in `extra-opts`"
-          (fn []
-            (nnoremap! :lhs [:expr] :rhs)
-            (nnoremap! :lhs1 :rhs {:expr true})
-            (let [opt {:expr true}]
-              (nnoremap! :lhs2 :rhs opt))
-            (let [{: replace_keycodes} (get-mapargs :n :lhs)]
-              (assert.is.same 1 replace_keycodes))
-            (let [{: replace_keycodes} (get-mapargs :n :lhs1)]
-              (assert.is_nil replace_keycodes))
-            (let [{: replace_keycodes} (get-mapargs :n :lhs2)]
-              (assert.is_nil replace_keycodes))))
-        (it "disables `replace_keycodes` when `literal` is set in `extra-opts`"
-          (fn []
-            (nnoremap! :lhs [:expr :literal] :rhs)
-            (let [{: replace_keycodes} (get-mapargs :n :lhs)]
-              (assert.is_nil replace_keycodes)))))
-      (describe :map-range!
-        (it "maps lhs in Normal mode and Visual mode"
-          (fn []
-            (map-range! :lhs :rhs)
-            (assert.is_same :rhs (get-rhs :n :lhs))
-            (assert.is_same :rhs (get-rhs :x :lhs))
-            (assert.is_same :rhs (get-rhs :v :lhs))
-            (assert.is_nil (get-rhs :s :lhs)))))
-      (describe :map-motion!
-        (it "`unmap`s `smap` internally without errors"
-          (fn []
-            (assert.has_no.errors #(map-motion! :lhs :rhs))
-            (let [bufnr (vim.api.nvim_get_current_buf)]
-              (assert.has_no.errors #(map-motion! [:<buffer>] :lhs :rhs))
-              (refresh-buffer)
-              (assert.has_no.errors #(map-motion! [:buffer bufnr] :lhs :rhs)))))
-        (it "`sunmap`s when lhs is visible key in compile time."
-          #(let [lhs :sym]
-             (smap! :lhs :old)
-             (smap! lhs :old)
-             (smap! :<Esc> :old)
-             (smap! :<C-f> :old)
-             (smap! :<k9> :old)
-             (smap! :<S-f> :old)
-             (assert.has_no.errors #(map-motion! :lhs :new))
-             (assert.has_no.errors #(map-motion! lhs :new))
-             (assert.has_no.errors #(map-motion! :<Esc> :new))
-             (assert.has_no.errors #(map-motion! :<C-f> :new))
-             (assert.has_no.errors #(map-motion! :<k9> :new))
-             (assert.has_no.errors #(map-motion! :<S-f> :new))
-             (assert.is_nil (get-rhs :s :lhs))
-             (assert.is.same :old (get-rhs :s lhs))
-             (assert.is.same :new (get-rhs :s :<Esc>))
-             (assert.is.same :new (get-rhs :s :<C-F>))
-             (assert.is.same :new (get-rhs :s :<k9>))
-             (assert.is_nil (get-rhs :s :<S-f>))))))))
+      (it "maps recursively with `remap` key in `extra-opts`"
+        (let [modes [:n :o :x]]
+          (noremap! modes [:remap] :lhs :rhs)
+          (each [_ m (ipairs modes)]
+            (let [{: noremap} (get-mapargs m :lhs)]
+              (assert.is.same 0 noremap))))))
+    (describe :nnoremap!
+      (it "can include extra-opts in either first or second arg"
+        (assert.has_no.errors #(nnoremap! [:nowait] :lhs :rhs))
+        (assert.has_no.errors #(nnoremap! :lhs [:nowait] :rhs)))
+      (it "maps to current buffer with `<buffer>`"
+        (nnoremap! [:<buffer>] :lhs :rhs)
+        (assert.is.same :rhs (buf-get-rhs 0 :n :lhs)))
+      (it "maps to specific buffer with `buffer`"
+        (let [bufnr (vim.api.nvim_get_current_buf)]
+          (refresh-buffer)
+          (nnoremap! [:buffer bufnr] :lhs :rhs)
+          (assert.is_nil (buf-get-rhs 0 :n :lhs))
+          (assert.is.same :rhs (buf-get-rhs bufnr :n :lhs))))
+      (it "set a list which will result in string without callback"
+        (nnoremap! :lhs (.. :r :h :s))
+        (nnoremap! :lhs1 (.. (<Cmd> :foobar) :<Esc>))
+        (assert.is.same :rhs (get-rhs :n :lhs))
+        (assert.is.same :<Cmd>foobar<CR><Esc> (get-rhs :n :lhs1)))
+      (it "can set Ex command in autocmds with `<command>` key"
+        (nnoremap! :lhs1 [:<command>] default-rhs)
+        (nnoremap! :lhs2 [:<command>] (.. :foo :bar))
+        (assert.is.same default-rhs (get-rhs :n :lhs1))
+        (assert.is.same :foobar (get-rhs :n :lhs2)))
+      (it "can set Ex command in autocmds with `ex` key"
+        (nnoremap! :lhs1 [:ex] default-rhs)
+        (nnoremap! :lhs2 [:ex] (.. :foo :bar))
+        (assert.is.same default-rhs (get-rhs :n :lhs1))
+        (assert.is.same :foobar (get-rhs :n :lhs2)))
+      (it "can set callback function in autocmds with `<callback>` key"
+        (nnoremap! :lhs1 [:<callback>] default-callback)
+        ;; Note: vim.api.nvim_get_keymap cannot get vim function.
+        (nnoremap! :lhs2 [:<callback>] (new-callback (.. :foo :bar)))
+        (assert.is.same default-callback (get-callback :n :lhs1))
+        (assert.is_true (= :function (type (get-callback :n :lhs2)))))
+      (it "can set callback function in autocmds with `cb` key"
+        (nnoremap! :lhs1 [:cb] default-callback)
+        (nnoremap! :lhs2 [:cb] (new-callback (.. :foo :bar)))
+        (assert.is.same default-callback (get-callback :n :lhs1))
+        (assert.is_true (= :function (type (get-callback :n :lhs2)))))
+      (it "enables `replace_keycodes` when `expr` is set in `extra-opts`"
+        (nnoremap! :lhs [:expr] :rhs)
+        (nnoremap! :lhs1 :rhs {:expr true})
+        (let [opt {:expr true}]
+          (nnoremap! :lhs2 :rhs opt))
+        (let [{: replace_keycodes} (get-mapargs :n :lhs)]
+          (assert.is.same 1 replace_keycodes))
+        (let [{: replace_keycodes} (get-mapargs :n :lhs1)]
+          (assert.is_nil replace_keycodes))
+        (let [{: replace_keycodes} (get-mapargs :n :lhs2)]
+          (assert.is_nil replace_keycodes)))
+      (it "disables `replace_keycodes` when `literal` is set in `extra-opts`"
+        (nnoremap! :lhs [:expr :literal] :rhs)
+        (let [{: replace_keycodes} (get-mapargs :n :lhs)]
+          (assert.is_nil replace_keycodes))))
+    (describe :map-range!
+      (it "maps lhs in Normal mode and Visual mode"
+        (map-range! :lhs :rhs)
+        (assert.is_same :rhs (get-rhs :n :lhs))
+        (assert.is_same :rhs (get-rhs :x :lhs))
+        (assert.is_same :rhs (get-rhs :v :lhs))
+        (assert.is_nil (get-rhs :s :lhs))))
+    (describe :map-motion!
+      (it "`unmap`s `smap` internally without errors"
+        (assert.has_no.errors #(map-motion! :lhs :rhs))
+        (let [bufnr (vim.api.nvim_get_current_buf)]
+          (assert.has_no.errors #(map-motion! [:<buffer>] :lhs :rhs))
+          (refresh-buffer)
+          (assert.has_no.errors #(map-motion! [:buffer bufnr] :lhs :rhs))))
+      (it "`sunmap`s when lhs is visible key in compile time."
+        (let [lhs :sym]
+          (smap! :lhs :old)
+          (smap! lhs :old)
+          (smap! :<Esc> :old)
+          (smap! :<C-f> :old)
+          (smap! :<k9> :old)
+          (smap! :<S-f> :old)
+          (assert.has_no.errors #(map-motion! :lhs :new))
+          (assert.has_no.errors #(map-motion! lhs :new))
+          (assert.has_no.errors #(map-motion! :<Esc> :new))
+          (assert.has_no.errors #(map-motion! :<C-f> :new))
+          (assert.has_no.errors #(map-motion! :<k9> :new))
+          (assert.has_no.errors #(map-motion! :<S-f> :new))
+          (assert.is_nil (get-rhs :s :lhs))
+          (assert.is.same :old (get-rhs :s lhs))
+          (assert.is.same :new (get-rhs :s :<Esc>))
+          (assert.is.same :new (get-rhs :s :<C-F>))
+          (assert.is.same :new (get-rhs :s :<k9>))
+          (assert.is_nil (get-rhs :s :<S-f>)))))))

--- a/tests/spec/keymap_spec.fnl
+++ b/tests/spec/keymap_spec.fnl
@@ -1,3 +1,4 @@
+(import-macros {: describe} :_busted_macros)
 (import-macros {: map!
                 : noremap!
                 : nnoremap!
@@ -61,235 +62,227 @@
                        (pcall vim.api.nvim_del_keymap mode :lhs)
                        (assert.is_nil (get-rhs mode :lhs))))))
     (describe :map!
-      (fn []
-        (it "sets callback function with quoted symbol"
-          #(do
-             (map! :n :lhs `default-callback)
-             (assert.is_same default-callback (get-callback :n :lhs))))
-        (it "sets callback function with quoted multi-symbol"
-          #(let [desc :multi.sym]
-             (map! :n :lhs `default.multi.sym {: desc})
-             (assert.is_same default.multi.sym (get-callback :n :lhs))))
-        (it "sets callback function with quoted list"
-          #(let [desc :list]
-             (map! :n :lhs `(default-callback :foo :bar) {: desc})
-             (assert.is_same desc (. (get-mapargs :n :lhs) :desc))))
-        (it "set callback function in string for `vim.fn.Test"
-          (fn []
-            (map! :n :lhs `vim.fn.Test)
-            (assert.is_same vim.fn.Test (get-callback :n :lhs))))
-        (it "maps non-recursively by default"
-          #(let [mode :n
-                 modes [:n :o :t]]
-             (map! mode :lhs :rhs)
-             (map! modes :lhs :rhs)
-             (let [{: noremap} (get-mapargs mode :lhs)]
-               (assert.is.same 1 noremap))
-             (each [_ m (ipairs modes)]
-               (let [{: noremap} (get-mapargs m :lhs)]
-                 (assert.is.same 1 noremap)))))
-        (it "is also available to recursive mappings"
+      (it "sets callback function with quoted symbol"
+        #(do
+          (map! :n :lhs `default-callback)
+          (assert.is_same default-callback (get-callback :n :lhs))))
+      (it "sets callback function with quoted multi-symbol"
+        #(let [desc :multi.sym]
+           (map! :n :lhs `default.multi.sym {: desc})
+           (assert.is_same default.multi.sym (get-callback :n :lhs))))
+      (it "sets callback function with quoted list"
+        #(let [desc :list]
+           (map! :n :lhs `(default-callback :foo :bar) {: desc})
+           (assert.is_same desc (. (get-mapargs :n :lhs) :desc))))
+      (it "set callback function in string for `vim.fn.Test"
+        (fn []
+          (map! :n :lhs `vim.fn.Test)
+          (assert.is_same vim.fn.Test (get-callback :n :lhs))))
+      (it "maps non-recursively by default"
+        #(let [mode :n
+               modes [:n :o :t]]
+           (map! mode :lhs :rhs)
+           (map! modes :lhs :rhs)
+           (let [{: noremap} (get-mapargs mode :lhs)]
+             (assert.is.same 1 noremap))
+           (each [_ m (ipairs modes)]
+             (let [{: noremap} (get-mapargs m :lhs)]
+               (assert.is.same 1 noremap)))))
+      (it "is also available to recursive mappings"
+        #(let [mode :n]
+           (map! :o [:remap] :lhs :rhs)
+           (map! mode [:remap] :lhs :rhs)
+           (let [{: noremap} (get-mapargs :o :lhs)]
+             (assert.is.same 0 noremap))
+           (let [{: noremap} (get-mapargs mode :lhs)]
+             (assert.is.same 0 noremap))))
+      (it "gives priority to `api-opts`"
+        #(let [mode :n
+               modes [:i :c :t]
+               api-opts {:noremap true}]
+           (map! :o :lhs :rhs api-opts)
+           (map! mode :lhs :rhs api-opts)
+           (map! modes :lhs :rhs api-opts)
+           (let [{: noremap} (get-mapargs :o :lhs)]
+             (assert.is.same 1 noremap))
+           (let [{: noremap} (get-mapargs mode :lhs)]
+             (assert.is.same 1 noremap))
+           (each [_ m (ipairs modes)]
+             (let [{: noremap} (get-mapargs m :lhs)]
+               (assert.is.same 1 noremap)))))
+      (it "sets callback via macro with quote"
+        (fn []
+          (map! :n :lhs `(macro-callback))
+          (assert.is_not_nil (get-callback :n :lhs))))
+      (it "set command in macro with no args"
+        (fn []
+          (map! :n :lhs (macro-command))
+          (assert.is_same :macro-command (get-rhs :n :lhs))))
+      (it "set command in macro with some args"
+        (fn []
+          (map! :n :lhs (macro-command :foo :bar))
+          (assert.is_same :macro-command (get-rhs :n :lhs))))
+      (it "maps multiple mode mappings with a sequence at once"
+        #(let [modes [:n :c :t]]
+           (noremap! modes :lhs :rhs)
+           (each [_ mode (ipairs modes)]
+             (assert.is.same :rhs (get-rhs mode :lhs)))))
+      (it "maps multiple mode mappings with a bare-string at once"
+        #(do
+           (noremap! :nct :lhs :rhs)
+           (each [mode (-> :nct (: :gmatch "."))]
+             (assert.is.same :rhs (get-rhs mode :lhs)))))
+      (it "enables `replace_keycodes` with `expr` in `extra-opts`"
+        #(let [modes [:n]]
+           (map! modes [:expr] :lhs :rhs)
+           (let [{: replace_keycodes} (get-mapargs :n :lhs)]
+             (assert.is.same 1 replace_keycodes))))
+      (it "disables `replace_keycodes` with `literal` in `extra-opts`"
+        #(let [modes [:n]]
+           (map! modes [:expr :literal] :lhs :rhs)
+           (let [{: replace_keycodes} (get-mapargs :n :lhs)]
+             (assert.is_nil replace_keycodes)))))
+    (describe :unmap!
+      (it "`unmap`s key"
+        (fn []
+          (nnoremap! :lhs :rhs)
+          (assert.is.same :rhs (get-rhs :n :lhs))
+          (unmap! :n :lhs)
+          (assert.is_nil (get-rhs :n :lhs))))
+      (it "can unmap buffer local key"
+        (fn []
+          (let [bufnr (vim.api.nvim_get_current_buf)]
+            (nnoremap! [:<buffer>] :lhs :rhs)
+            (assert.is.same :rhs (buf-get-rhs 0 :n :lhs))
+            (unmap! 0 :n :lhs)
+            (assert.is_nil (buf-get-rhs 0 :n :lhs))
+            (nnoremap! [:buffer bufnr] :lhs :rhs)
+            (assert.is.same :rhs (buf-get-rhs bufnr :n :lhs))
+            (unmap! bufnr :n :lhs)
+            (assert.is_nil (buf-get-rhs bufnr :n :lhs))))))
+    (describe :<Cmd>/<C-u>
+      (it "is set to rhs as a string"
+        (fn []
+          (assert.has_no.errors #(nnoremap! :lhs (<Cmd> "Do something")))
+          (assert.is.same "<Cmd>Do something<CR>" (get-rhs :n :lhs))
+          (assert.has_no.errors #(nnoremap! [:<buffer>] :lhs
+                                            (<C-u> "Do something")))
+          (assert.is.same ":<C-U>Do something<CR>" (buf-get-rhs 0 :n :lhs)))))
+    (describe "(deprecated)"
+      (describe :noremap!
+        (it "maps lhs to rhs with `noremap` set to `true` represented by `1`"
           #(let [mode :n]
-             (map! :o [:remap] :lhs :rhs)
-             (map! mode [:remap] :lhs :rhs)
-             (let [{: noremap} (get-mapargs :o :lhs)]
-               (assert.is.same 0 noremap))
+             (noremap! mode :lhs :rhs)
              (let [{: noremap} (get-mapargs mode :lhs)]
-               (assert.is.same 0 noremap))))
-        (it "gives priority to `api-opts`"
-          #(let [mode :n
-                 modes [:i :c :t]
-                 api-opts {:noremap true}]
-             (map! :o :lhs :rhs api-opts)
-             (map! mode :lhs :rhs api-opts)
-             (map! modes :lhs :rhs api-opts)
-             (let [{: noremap} (get-mapargs :o :lhs)]
-               (assert.is.same 1 noremap))
-             (let [{: noremap} (get-mapargs mode :lhs)]
-               (assert.is.same 1 noremap))
-             (each [_ m (ipairs modes)]
-               (let [{: noremap} (get-mapargs m :lhs)]
-                 (assert.is.same 1 noremap)))))
-        (it "sets callback via macro with quote"
-          (fn []
-            (map! :n :lhs `(macro-callback))
-            (assert.is_not_nil (get-callback :n :lhs))))
-        (it "set command in macro with no args"
-          (fn []
-            (map! :n :lhs (macro-command))
-            (assert.is_same :macro-command (get-rhs :n :lhs))))
-        (it "set command in macro with some args"
-          (fn []
-            (map! :n :lhs (macro-command :foo :bar))
-            (assert.is_same :macro-command (get-rhs :n :lhs))))
-        (it "maps multiple mode mappings with a sequence at once"
-          #(let [modes [:n :c :t]]
+               (assert.is.same 1 noremap))))
+        (it "maps multiple mode mappings with sequence at once"
+          #(let [modes [:n :t :o]]
              (noremap! modes :lhs :rhs)
              (each [_ mode (ipairs modes)]
                (assert.is.same :rhs (get-rhs mode :lhs)))))
-        (it "maps multiple mode mappings with a bare-string at once"
-          #(do
-             (noremap! :nct :lhs :rhs)
-             (each [mode (-> :nct (: :gmatch "."))]
-               (assert.is.same :rhs (get-rhs mode :lhs)))))
-        (it "enables `replace_keycodes` with `expr` in `extra-opts`"
-          #(let [modes [:n]]
-             (map! modes [:expr] :lhs :rhs)
-             (let [{: replace_keycodes} (get-mapargs :n :lhs)]
-               (assert.is.same 1 replace_keycodes))))
-        (it "disables `replace_keycodes` with `literal` in `extra-opts`"
-          #(let [modes [:n]]
-             (map! modes [:expr :literal] :lhs :rhs)
-             (let [{: replace_keycodes} (get-mapargs :n :lhs)]
-               (assert.is_nil replace_keycodes))))))
-    (describe :unmap!
-      (fn []
-        (it "`unmap`s key"
+        (it "maps recursively with `remap` key in `extra-opts`"
+          #(let [modes [:n :o :x]]
+             (noremap! modes [:remap] :lhs :rhs)
+             (each [_ m (ipairs modes)]
+               (let [{: noremap} (get-mapargs m :lhs)]
+                 (assert.is.same 0 noremap))))))
+      (describe :nnoremap!
+        (it "can include extra-opts in either first or second arg"
           (fn []
-            (nnoremap! :lhs :rhs)
-            (assert.is.same :rhs (get-rhs :n :lhs))
-            (unmap! :n :lhs)
-            (assert.is_nil (get-rhs :n :lhs))))
-        (it "can unmap buffer local key"
+            (assert.has_no.errors #(nnoremap! [:nowait] :lhs :rhs))
+            (assert.has_no.errors #(nnoremap! :lhs [:nowait] :rhs))))
+        (it "maps to current buffer with `<buffer>`"
+          (fn []
+            (nnoremap! [:<buffer>] :lhs :rhs)
+            (assert.is.same :rhs (buf-get-rhs 0 :n :lhs))))
+        (it "maps to specific buffer with `buffer`"
           (fn []
             (let [bufnr (vim.api.nvim_get_current_buf)]
-              (nnoremap! [:<buffer>] :lhs :rhs)
-              (assert.is.same :rhs (buf-get-rhs 0 :n :lhs))
-              (unmap! 0 :n :lhs)
-              (assert.is_nil (buf-get-rhs 0 :n :lhs))
+              (refresh-buffer)
               (nnoremap! [:buffer bufnr] :lhs :rhs)
-              (assert.is.same :rhs (buf-get-rhs bufnr :n :lhs))
-              (unmap! bufnr :n :lhs)
-              (assert.is_nil (buf-get-rhs bufnr :n :lhs)))))))
-    (describe :<Cmd>/<C-u>
-      (fn []
-        (it "is set to rhs as a string"
+              (assert.is_nil (buf-get-rhs 0 :n :lhs))
+              (assert.is.same :rhs (buf-get-rhs bufnr :n :lhs)))))
+        (it "set a list which will result in string without callback"
           (fn []
-            (assert.has_no.errors #(nnoremap! :lhs (<Cmd> "Do something")))
-            (assert.is.same "<Cmd>Do something<CR>" (get-rhs :n :lhs))
-            (assert.has_no.errors #(nnoremap! [:<buffer>] :lhs
-                                              (<C-u> "Do something")))
-            (assert.is.same ":<C-U>Do something<CR>" (buf-get-rhs 0 :n :lhs))))))
-    (insulate "(deprecated)"
-      (fn []
-        (describe :noremap!
+            (nnoremap! :lhs (.. :r :h :s))
+            (nnoremap! :lhs1 (.. (<Cmd> :foobar) :<Esc>))
+            (assert.is.same :rhs (get-rhs :n :lhs))
+            (assert.is.same :<Cmd>foobar<CR><Esc> (get-rhs :n :lhs1))))
+        (it "can set Ex command in autocmds with `<command>` key"
           (fn []
-            (it "maps lhs to rhs with `noremap` set to `true` represented by `1`"
-              #(let [mode :n]
-                 (noremap! mode :lhs :rhs)
-                 (let [{: noremap} (get-mapargs mode :lhs)]
-                   (assert.is.same 1 noremap))))
-            (it "maps multiple mode mappings with sequence at once"
-              #(let [modes [:n :t :o]]
-                 (noremap! modes :lhs :rhs)
-                 (each [_ mode (ipairs modes)]
-                   (assert.is.same :rhs (get-rhs mode :lhs)))))
-            (it "maps recursively with `remap` key in `extra-opts`"
-              #(let [modes [:n :o :x]]
-                 (noremap! modes [:remap] :lhs :rhs)
-                 (each [_ m (ipairs modes)]
-                   (let [{: noremap} (get-mapargs m :lhs)]
-                     (assert.is.same 0 noremap)))))))
-        (describe :nnoremap!
+            (nnoremap! :lhs1 [:<command>] default-rhs)
+            (nnoremap! :lhs2 [:<command>] (.. :foo :bar))
+            (assert.is.same default-rhs (get-rhs :n :lhs1))
+            (assert.is.same :foobar (get-rhs :n :lhs2))))
+        (it "can set Ex command in autocmds with `ex` key"
           (fn []
-            (it "can include extra-opts in either first or second arg"
-              (fn []
-                (assert.has_no.errors #(nnoremap! [:nowait] :lhs :rhs))
-                (assert.has_no.errors #(nnoremap! :lhs [:nowait] :rhs))))
-            (it "maps to current buffer with `<buffer>`"
-              (fn []
-                (nnoremap! [:<buffer>] :lhs :rhs)
-                (assert.is.same :rhs (buf-get-rhs 0 :n :lhs))))
-            (it "maps to specific buffer with `buffer`"
-              (fn []
-                (let [bufnr (vim.api.nvim_get_current_buf)]
-                  (refresh-buffer)
-                  (nnoremap! [:buffer bufnr] :lhs :rhs)
-                  (assert.is_nil (buf-get-rhs 0 :n :lhs))
-                  (assert.is.same :rhs (buf-get-rhs bufnr :n :lhs)))))
-            (it "set a list which will result in string without callback"
-              (fn []
-                (nnoremap! :lhs (.. :r :h :s))
-                (nnoremap! :lhs1 (.. (<Cmd> :foobar) :<Esc>))
-                (assert.is.same :rhs (get-rhs :n :lhs))
-                (assert.is.same :<Cmd>foobar<CR><Esc> (get-rhs :n :lhs1))))
-            (it "can set Ex command in autocmds with `<command>` key"
-              (fn []
-                (nnoremap! :lhs1 [:<command>] default-rhs)
-                (nnoremap! :lhs2 [:<command>] (.. :foo :bar))
-                (assert.is.same default-rhs (get-rhs :n :lhs1))
-                (assert.is.same :foobar (get-rhs :n :lhs2))))
-            (it "can set Ex command in autocmds with `ex` key"
-              (fn []
-                (nnoremap! :lhs1 [:ex] default-rhs)
-                (nnoremap! :lhs2 [:ex] (.. :foo :bar))
-                (assert.is.same default-rhs (get-rhs :n :lhs1))
-                (assert.is.same :foobar (get-rhs :n :lhs2))))
-            (it "can set callback function in autocmds with `<callback>` key"
-              (fn []
-                (nnoremap! :lhs1 [:<callback>] default-callback)
-                ;; Note: vim.api.nvim_get_keymap cannot get vim function.
-                (nnoremap! :lhs2 [:<callback>] (new-callback (.. :foo :bar)))
-                (assert.is.same default-callback (get-callback :n :lhs1))
-                (assert.is_true (= :function (type (get-callback :n :lhs2))))))
-            (it "can set callback function in autocmds with `cb` key"
-              (fn []
-                (nnoremap! :lhs1 [:cb] default-callback)
-                (nnoremap! :lhs2 [:cb] (new-callback (.. :foo :bar)))
-                (assert.is.same default-callback (get-callback :n :lhs1))
-                (assert.is_true (= :function (type (get-callback :n :lhs2))))))
-            (it "enables `replace_keycodes` when `expr` is set in `extra-opts`"
-              (fn []
-                (nnoremap! :lhs [:expr] :rhs)
-                (nnoremap! :lhs1 :rhs {:expr true})
-                (let [opt {:expr true}]
-                  (nnoremap! :lhs2 :rhs opt))
-                (let [{: replace_keycodes} (get-mapargs :n :lhs)]
-                  (assert.is.same 1 replace_keycodes))
-                (let [{: replace_keycodes} (get-mapargs :n :lhs1)]
-                  (assert.is_nil replace_keycodes))
-                (let [{: replace_keycodes} (get-mapargs :n :lhs2)]
-                  (assert.is_nil replace_keycodes))))
-            (it "disables `replace_keycodes` when `literal` is set in `extra-opts`"
-              (fn []
-                (nnoremap! :lhs [:expr :literal] :rhs)
-                (let [{: replace_keycodes} (get-mapargs :n :lhs)]
-                  (assert.is_nil replace_keycodes))))))
-        (describe :map-range!
+            (nnoremap! :lhs1 [:ex] default-rhs)
+            (nnoremap! :lhs2 [:ex] (.. :foo :bar))
+            (assert.is.same default-rhs (get-rhs :n :lhs1))
+            (assert.is.same :foobar (get-rhs :n :lhs2))))
+        (it "can set callback function in autocmds with `<callback>` key"
           (fn []
-            (it "maps lhs in Normal mode and Visual mode"
-              (fn []
-                (map-range! :lhs :rhs)
-                (assert.is_same :rhs (get-rhs :n :lhs))
-                (assert.is_same :rhs (get-rhs :x :lhs))
-                (assert.is_same :rhs (get-rhs :v :lhs))
-                (assert.is_nil (get-rhs :s :lhs))))))
-        (describe :map-motion!
+            (nnoremap! :lhs1 [:<callback>] default-callback)
+            ;; Note: vim.api.nvim_get_keymap cannot get vim function.
+            (nnoremap! :lhs2 [:<callback>] (new-callback (.. :foo :bar)))
+            (assert.is.same default-callback (get-callback :n :lhs1))
+            (assert.is_true (= :function (type (get-callback :n :lhs2))))))
+        (it "can set callback function in autocmds with `cb` key"
           (fn []
-            (it "`unmap`s `smap` internally without errors"
-              (fn []
-                (assert.has_no.errors #(map-motion! :lhs :rhs))
-                (let [bufnr (vim.api.nvim_get_current_buf)]
-                  (assert.has_no.errors #(map-motion! [:<buffer>] :lhs :rhs))
-                  (refresh-buffer)
-                  (assert.has_no.errors #(map-motion! [:buffer bufnr] :lhs :rhs)))))
-            (it "`sunmap`s when lhs is visible key in compile time."
-              #(let [lhs :sym]
-                 (smap! :lhs :old)
-                 (smap! lhs :old)
-                 (smap! :<Esc> :old)
-                 (smap! :<C-f> :old)
-                 (smap! :<k9> :old)
-                 (smap! :<S-f> :old)
-                 (assert.has_no.errors #(map-motion! :lhs :new))
-                 (assert.has_no.errors #(map-motion! lhs :new))
-                 (assert.has_no.errors #(map-motion! :<Esc> :new))
-                 (assert.has_no.errors #(map-motion! :<C-f> :new))
-                 (assert.has_no.errors #(map-motion! :<k9> :new))
-                 (assert.has_no.errors #(map-motion! :<S-f> :new))
-                 (assert.is_nil (get-rhs :s :lhs))
-                 (assert.is.same :old (get-rhs :s lhs))
-                 (assert.is.same :new (get-rhs :s :<Esc>))
-                 (assert.is.same :new (get-rhs :s :<C-F>))
-                 (assert.is.same :new (get-rhs :s :<k9>))
-                 (assert.is_nil (get-rhs :s :<S-f>))))))))))
+            (nnoremap! :lhs1 [:cb] default-callback)
+            (nnoremap! :lhs2 [:cb] (new-callback (.. :foo :bar)))
+            (assert.is.same default-callback (get-callback :n :lhs1))
+            (assert.is_true (= :function (type (get-callback :n :lhs2))))))
+        (it "enables `replace_keycodes` when `expr` is set in `extra-opts`"
+          (fn []
+            (nnoremap! :lhs [:expr] :rhs)
+            (nnoremap! :lhs1 :rhs {:expr true})
+            (let [opt {:expr true}]
+              (nnoremap! :lhs2 :rhs opt))
+            (let [{: replace_keycodes} (get-mapargs :n :lhs)]
+              (assert.is.same 1 replace_keycodes))
+            (let [{: replace_keycodes} (get-mapargs :n :lhs1)]
+              (assert.is_nil replace_keycodes))
+            (let [{: replace_keycodes} (get-mapargs :n :lhs2)]
+              (assert.is_nil replace_keycodes))))
+        (it "disables `replace_keycodes` when `literal` is set in `extra-opts`"
+          (fn []
+            (nnoremap! :lhs [:expr :literal] :rhs)
+            (let [{: replace_keycodes} (get-mapargs :n :lhs)]
+              (assert.is_nil replace_keycodes)))))
+      (describe :map-range!
+        (it "maps lhs in Normal mode and Visual mode"
+          (fn []
+            (map-range! :lhs :rhs)
+            (assert.is_same :rhs (get-rhs :n :lhs))
+            (assert.is_same :rhs (get-rhs :x :lhs))
+            (assert.is_same :rhs (get-rhs :v :lhs))
+            (assert.is_nil (get-rhs :s :lhs)))))
+      (describe :map-motion!
+        (it "`unmap`s `smap` internally without errors"
+          (fn []
+            (assert.has_no.errors #(map-motion! :lhs :rhs))
+            (let [bufnr (vim.api.nvim_get_current_buf)]
+              (assert.has_no.errors #(map-motion! [:<buffer>] :lhs :rhs))
+              (refresh-buffer)
+              (assert.has_no.errors #(map-motion! [:buffer bufnr] :lhs :rhs)))))
+        (it "`sunmap`s when lhs is visible key in compile time."
+          #(let [lhs :sym]
+             (smap! :lhs :old)
+             (smap! lhs :old)
+             (smap! :<Esc> :old)
+             (smap! :<C-f> :old)
+             (smap! :<k9> :old)
+             (smap! :<S-f> :old)
+             (assert.has_no.errors #(map-motion! :lhs :new))
+             (assert.has_no.errors #(map-motion! lhs :new))
+             (assert.has_no.errors #(map-motion! :<Esc> :new))
+             (assert.has_no.errors #(map-motion! :<C-f> :new))
+             (assert.has_no.errors #(map-motion! :<k9> :new))
+             (assert.has_no.errors #(map-motion! :<S-f> :new))
+             (assert.is_nil (get-rhs :s :lhs))
+             (assert.is.same :old (get-rhs :s lhs))
+             (assert.is.same :new (get-rhs :s :<Esc>))
+             (assert.is.same :new (get-rhs :s :<C-F>))
+             (assert.is.same :new (get-rhs :s :<k9>))
+             (assert.is_nil (get-rhs :s :<S-f>))))))))

--- a/tests/spec/keymap_spec.fnl
+++ b/tests/spec/keymap_spec.fnl
@@ -63,7 +63,7 @@
                        (assert.is_nil (get-rhs mode :lhs))))))
     (describe :map!
       (it "sets callback function with quoted symbol"
-        #(do
+        (fn []
           (map! :n :lhs `default-callback)
           (assert.is_same default-callback (get-callback :n :lhs))))
       (it "sets callback function with quoted multi-symbol"
@@ -128,10 +128,10 @@
            (each [_ mode (ipairs modes)]
              (assert.is.same :rhs (get-rhs mode :lhs)))))
       (it "maps multiple mode mappings with a bare-string at once"
-        #(do
-           (noremap! :nct :lhs :rhs)
-           (each [mode (-> :nct (: :gmatch "."))]
-             (assert.is.same :rhs (get-rhs mode :lhs)))))
+        (fn []
+          (noremap! :nct :lhs :rhs)
+          (each [mode (-> :nct (: :gmatch "."))]
+            (assert.is.same :rhs (get-rhs mode :lhs)))))
       (it "enables `replace_keycodes` with `expr` in `extra-opts`"
         #(let [modes [:n]]
            (map! modes [:expr] :lhs :rhs)

--- a/tests/spec/option_spec.fnl
+++ b/tests/spec/option_spec.fnl
@@ -1,3 +1,4 @@
+(import-macros {: describe} :_busted_macros)
 (import-macros {: set!
                 : set+
                 : set^
@@ -65,682 +66,664 @@
     (assert.is_same val (. vim.o name))))
 
 (describe :options
-  (fn []
-    (before_each reset-context)
-    (describe :set!
+  (before_each reset-context)
+  (describe :set!
+    (it "is case-insensitive at option name"
       (fn []
-        (it "is case-insensitive at option name"
-          (fn []
-            (vim.cmd "set foldlevel=2")
-            (let [vals (get-o-lo-go :foldlevel)]
-              (reset-context)
-              (set! :foldLevel 2)
-              (assert.is_same vals (get-o-lo-go :foldlevel)))))
-        (it "can update option value with boolean"
-          (fn []
-            (vim.cmd "set nowrap")
-            (let [vals (get-o-lo-go :wrap)]
-              (reset-context)
-              (set! :wrap false)
-              (assert.is_same vals (get-o-lo-go :wrap)))))
-        (it "can update option value with number"
-          (fn []
-            (vim.cmd "set foldlevel=2")
-            (let [vals (get-o-lo-go :foldlevel)]
-              (reset-context)
-              (set! :foldlevel 2)
-              (assert.is_same vals (get-o-lo-go :foldlevel)))))
-        (it "can update option value with string"
-          (fn []
-            (vim.cmd "set signcolumn=no")
-            (let [vals (get-o-lo-go :signcolumn)]
-              (reset-context)
-              (set! :signcolumn :no)
-              (assert.is_same vals (get-o-lo-go :signcolumn)))))
-        (it "can update option value with sequence"
-          (fn []
-            (vim.cmd "set path=/foo,/bar,/baz")
-            (let [vals (get-o-lo-go :path)]
-              (reset-context)
-              (set! :path [:/foo :/bar :/baz])
-              (assert.is_same vals (get-o-lo-go :path)))))
-        (it "can update option value with kv-table"
-          (fn []
-            (vim.cmd "set listchars=eol:a,tab:abc,space:a")
-            (let [vals (get-o-lo-go :listchars)]
-              (reset-context)
-              (set! :listchars {:eol :a :tab :abc :space :a})
-              (assert.is_same vals (get-o-lo-go :listchars)))))
-        (it "can update some option value with nil"
-          (fn []
-            (set vim.opt.foldlevel nil)
-            (let [vals (get-o-lo-go :foldlevel)]
-              (reset-context)
-              (set! :foldlevel nil)
-              (assert.is_same vals (get-o-lo-go :foldlevel)))))
-        (it "can update some option value with symbol"
-          (fn []
-            (let [new-val 2]
-              (set vim.opt.foldlevel new-val)
-              (let [vals (get-o-lo-go :foldlevel)]
-                (reset-context)
-                (set! :foldlevel new-val)
-                (assert.is_same vals (get-o-lo-go :foldlevel))))))
-        (it "can update some option value with list"
-          (fn []
-            (let [return-val #2]
-              (set vim.opt.foldlevel (return-val))
-              (let [vals (get-o-lo-go :foldlevel)]
-                (reset-context)
-                (set! :foldlevel (return-val))
-                (assert.is_same vals (get-o-lo-go :foldlevel))
-                (assert.is_same vals (get-o-lo-go :foldlevel))))))
-        (it "can append option value of sequence"
-          (fn []
-            (vim.cmd "set path+=/foo,/bar,/baz")
-            (let [vals (get-o-lo-go :path)]
-              (reset-context)
-              (set! :path+ [:/foo :/bar :/baz])
-              (assert.is_same vals (get-o-lo-go :path)))))
-        (it "can prepend option value of sequence"
-          (fn []
-            (vim.cmd "set path^=/foo,/bar,/baz")
-            (let [vals (get-o-lo-go :path)]
-              (reset-context)
-              (set! :path^ [:/foo :/bar :/baz])
-              (assert.is_same vals (get-o-lo-go :path)))))
-        (it "can remove option value of sequence"
-          (fn []
-            (vim.cmd "set path-=/tmp,/var")
-            (let [vals (get-o-lo-go :path)]
-              (reset-context)
-              (set! :path- [:/tmp :/var])
-              (assert.is_same vals (get-o-lo-go :path)))))
-        (it "can append option value of kv-table"
-          (fn []
-            (: vim.opt.listchars :append {:lead :a :trail :b :extends :c})
-            (let [vals (get-o-lo-go :listchars)]
-              (reset-context)
-              (set! :listchars+ {:lead :a :trail :b :extends :c})
-              (assert.is_same vals (get-o-lo-go :listchars)))))
-        (it "can prepend option value of kv-table"
-          (fn []
-            (: vim.opt.listchars :prepend {:lead :a :trail :b :extends :c})
-            (let [vals (get-o-lo-go :listchars)]
-              (reset-context)
-              (set! :listchars^ {:lead :a :trail :b :extends :c})
-              (assert.is_same vals (get-o-lo-go :listchars)))))
-        (it "can remove option value of kv-table"
-          (fn []
-            (: vim.opt.listchars :remove [:eol :tab])
-            (let [vals (get-o-lo-go :listchars)]
-              (reset-context)
-              (set! :listchars- [:eol :tab])
-              (assert.is_same vals (get-o-lo-go :listchars))))))
-      (describe "with no value"
+        (vim.cmd "set foldlevel=2")
+        (let [vals (get-o-lo-go :foldlevel)]
+          (reset-context)
+          (set! :foldLevel 2)
+          (assert.is_same vals (get-o-lo-go :foldlevel)))))
+    (it "can update option value with boolean"
+      (fn []
+        (vim.cmd "set nowrap")
+        (let [vals (get-o-lo-go :wrap)]
+          (reset-context)
+          (set! :wrap false)
+          (assert.is_same vals (get-o-lo-go :wrap)))))
+    (it "can update option value with number"
+      (fn []
+        (vim.cmd "set foldlevel=2")
+        (let [vals (get-o-lo-go :foldlevel)]
+          (reset-context)
+          (set! :foldlevel 2)
+          (assert.is_same vals (get-o-lo-go :foldlevel)))))
+    (it "can update option value with string"
+      (fn []
+        (vim.cmd "set signcolumn=no")
+        (let [vals (get-o-lo-go :signcolumn)]
+          (reset-context)
+          (set! :signcolumn :no)
+          (assert.is_same vals (get-o-lo-go :signcolumn)))))
+    (it "can update option value with sequence"
+      (fn []
+        (vim.cmd "set path=/foo,/bar,/baz")
+        (let [vals (get-o-lo-go :path)]
+          (reset-context)
+          (set! :path [:/foo :/bar :/baz])
+          (assert.is_same vals (get-o-lo-go :path)))))
+    (it "can update option value with kv-table"
+      (fn []
+        (vim.cmd "set listchars=eol:a,tab:abc,space:a")
+        (let [vals (get-o-lo-go :listchars)]
+          (reset-context)
+          (set! :listchars {:eol :a :tab :abc :space :a})
+          (assert.is_same vals (get-o-lo-go :listchars)))))
+    (it "can update some option value with nil"
+      (fn []
+        (set vim.opt.foldlevel nil)
+        (let [vals (get-o-lo-go :foldlevel)]
+          (reset-context)
+          (set! :foldlevel nil)
+          (assert.is_same vals (get-o-lo-go :foldlevel)))))
+    (it "can update some option value with symbol"
+      (fn []
+        (let [new-val 2]
+          (set vim.opt.foldlevel new-val)
+          (let [vals (get-o-lo-go :foldlevel)]
+            (reset-context)
+            (set! :foldlevel new-val)
+            (assert.is_same vals (get-o-lo-go :foldlevel))))))
+    (it "can update some option value with list"
+      (fn []
+        (let [return-val #2]
+          (set vim.opt.foldlevel (return-val))
+          (let [vals (get-o-lo-go :foldlevel)]
+            (reset-context)
+            (set! :foldlevel (return-val))
+            (assert.is_same vals (get-o-lo-go :foldlevel))
+            (assert.is_same vals (get-o-lo-go :foldlevel))))))
+    (it "can append option value of sequence"
+      (fn []
+        (vim.cmd "set path+=/foo,/bar,/baz")
+        (let [vals (get-o-lo-go :path)]
+          (reset-context)
+          (set! :path+ [:/foo :/bar :/baz])
+          (assert.is_same vals (get-o-lo-go :path)))))
+    (it "can prepend option value of sequence"
+      (fn []
+        (vim.cmd "set path^=/foo,/bar,/baz")
+        (let [vals (get-o-lo-go :path)]
+          (reset-context)
+          (set! :path^ [:/foo :/bar :/baz])
+          (assert.is_same vals (get-o-lo-go :path)))))
+    (it "can remove option value of sequence"
+      (fn []
+        (vim.cmd "set path-=/tmp,/var")
+        (let [vals (get-o-lo-go :path)]
+          (reset-context)
+          (set! :path- [:/tmp :/var])
+          (assert.is_same vals (get-o-lo-go :path)))))
+    (it "can append option value of kv-table"
+      (fn []
+        (: vim.opt.listchars :append {:lead :a :trail :b :extends :c})
+        (let [vals (get-o-lo-go :listchars)]
+          (reset-context)
+          (set! :listchars+ {:lead :a :trail :b :extends :c})
+          (assert.is_same vals (get-o-lo-go :listchars)))))
+    (it "can prepend option value of kv-table"
+      (fn []
+        (: vim.opt.listchars :prepend {:lead :a :trail :b :extends :c})
+        (let [vals (get-o-lo-go :listchars)]
+          (reset-context)
+          (set! :listchars^ {:lead :a :trail :b :extends :c})
+          (assert.is_same vals (get-o-lo-go :listchars)))))
+    (it "can remove option value of kv-table"
+      (fn []
+        (: vim.opt.listchars :remove [:eol :tab])
+        (let [vals (get-o-lo-go :listchars)]
+          (reset-context)
+          (set! :listchars- [:eol :tab])
+          (assert.is_same vals (get-o-lo-go :listchars)))))
+    (describe "with no value"
+      (it "updates option value to `true`"
         (fn []
-          (it "updates option value to `true`"
-            (fn []
-              (vim.cmd "set nowrap")
-              (assert.is_false (get-o :wrap))
-              (set! :wrap)
-              (assert.is_true (get-o :wrap))))
-          (it "updates value to `true` even when option name is hidden in compile time"
-            (fn []
-              (vim.cmd "set nowrap")
-              (assert.is_false (get-o :wrap))
-              (let [name :wrap]
-                (set! name)
-                (assert.is_true (get-o name))))))))
-    (describe :setlocal!
-      (fn []
-        (it "can update option value with boolean"
-          (fn []
-            (vim.cmd "setlocal nowrap")
-            (let [vals (get-o-lo-go :wrap)]
-              (reset-context)
-              (setlocal! :wrap false)
-              (assert.is_same vals (get-o-lo-go :wrap)))))
-        (it "can update option value with number"
-          (fn []
-            (vim.cmd "setlocal foldlevel=2")
-            (let [vals (get-o-lo-go :foldlevel)]
-              (reset-context)
-              (setlocal! :foldlevel 2)
-              (assert.is_same vals (get-o-lo-go :foldlevel)))))
-        (it "can update option value with string"
-          (fn []
-            (vim.cmd "setlocal signcolumn=no")
-            (let [vals (get-o-lo-go :signcolumn)]
-              (reset-context)
-              (setlocal! :signcolumn :no)
-              (assert.is_same vals (get-o-lo-go :signcolumn)))))
-        (it "can update option value with sequence"
-          (fn []
-            (vim.cmd "setlocal path=/foo,/bar,/baz")
-            (let [vals (get-o-lo-go :path)]
-              (reset-context)
-              (setlocal! :path [:/foo :/bar :/baz])
-              (assert.is_same vals (get-o-lo-go :path)))))
-        (it "can update option value with kv-table"
-          (fn []
-            (vim.cmd "setlocal listchars=eol:a,tab:abc,space:a")
-            (let [vals (get-o-lo-go :listchars)]
-              (reset-context)
-              (setlocal! :listchars {:eol :a :tab :abc :space :a})
-              (assert.is_same vals (get-o-lo-go :listchars)))))
-        (it "can update some option value with nil"
-          (fn []
-            (set vim.opt_local.foldlevel nil)
-            (let [vals (get-o-lo-go :foldlevel)]
-              (reset-context)
-              (setlocal! :foldlevel nil)
-              (assert.is_same vals (get-o-lo-go :foldlevel)))))
-        (it "can update some option value with symbol"
-          (fn []
-            (let [new-val 2]
-              (set vim.opt_local.foldlevel new-val)
-              (let [vals (get-o-lo-go :foldlevel)]
-                (reset-context)
-                (setlocal! :foldlevel new-val)
-                (assert.is_same vals (get-o-lo-go :foldlevel))))))
-        (it "can update some option value with list"
-          (fn []
-            (let [return-val #2]
-              (set vim.opt_local.foldlevel (return-val))
-              (let [vals (get-o-lo-go :foldlevel)]
-                (reset-context)
-                (setlocal! :foldlevel (return-val))
-                (assert.is_same vals (get-o-lo-go :foldlevel))))))
-        (it "can append option value of sequence"
-          (fn []
-            (: vim.opt_local.path :append [:/foo :/bar :/baz])
-            (let [vals (get-o-lo-go :path)]
-              (reset-context)
-              (setlocal! :path+ [:/foo :/bar :/baz])
-              (assert.is_same vals (get-o-lo-go :path)))))
-        (it "can prepend option value of sequence"
-          (fn []
-            (: vim.opt_local.path :prepend [:/foo :/bar :/baz])
-            (let [vals (get-o-lo-go :path)]
-              (reset-context)
-              (setlocal! :path^ [:/foo :/bar :/baz])
-              (assert.is_same vals (get-o-lo-go :path)))))
-        (it "can remove option value of sequence"
-          (fn []
-            (: vim.opt_local.path :remove [:/tmp :/var])
-            (let [vals (get-o-lo-go :path)]
-              (reset-context)
-              (setlocal! :path- [:/tmp :/var])
-              (assert.is_same vals (get-o-lo-go :path)))))
-        (it "can append option value of kv-table"
-          (fn []
-            (: vim.opt_local.listchars :append {:lead :a :trail :b :extends :c})
-            (let [vals (get-o-lo-go :listchars)]
-              (reset-context)
-              (setlocal! :listchars+ {:lead :a :trail :b :extends :c})
-              (assert.is_same vals (get-o-lo-go :listchars)))))
-        (it "can prepend option value of kv-table"
-          (fn []
-            (: vim.opt_local.listchars :prepend
-               {:lead :a :trail :b :extends :c})
-            (let [vals (get-o-lo-go :listchars)]
-              (reset-context)
-              (setlocal! :listchars^ {:lead :a :trail :b :extends :c})
-              (assert.is_same vals (get-o-lo-go :listchars)))))
-        (it "can remove option value of kv-table"
-          (fn []
-            (: vim.opt_local.listchars :remove [:eol :tab])
-            (let [vals (get-o-lo-go :listchars)]
-              (reset-context)
-              (setlocal! :listchars- [:eol :tab])
-              (assert.is_same vals (get-o-lo-go :listchars))))))
-      (describe "with no value"
+          (vim.cmd "set nowrap")
+          (assert.is_false (get-o :wrap))
+          (set! :wrap)
+          (assert.is_true (get-o :wrap))))
+      (it "updates value to `true` even when option name is hidden in compile time"
         (fn []
-          (it "updates option value to `true`"
-            (fn []
-              (vim.cmd "setlocal nowrap")
-              (assert.is_false (get-lo :wrap))
-              (setlocal! :wrap)
-              (assert.is_true (get-lo :wrap))))
-          (it "updates value to `true` even when option name is hidden in compile time"
-            (fn []
-              (vim.cmd "setlocal nowrap")
-              (assert.is_false (get-lo :wrap))
-              (let [name :wrap]
-                (setlocal! name)
-                (assert.is_true (get-lo name)))))))
-      (describe "for &l:formatoptions"
+          (vim.cmd "set nowrap")
+          (assert.is_false (get-o :wrap))
+          (let [name :wrap]
+            (set! name)
+            (assert.is_true (get-o name)))))))
+  (describe :setlocal!
+    (it "can update option value with boolean"
+      (fn []
+        (vim.cmd "setlocal nowrap")
+        (let [vals (get-o-lo-go :wrap)]
+          (reset-context)
+          (setlocal! :wrap false)
+          (assert.is_same vals (get-o-lo-go :wrap)))))
+    (it "can update option value with number"
+      (fn []
+        (vim.cmd "setlocal foldlevel=2")
+        (let [vals (get-o-lo-go :foldlevel)]
+          (reset-context)
+          (setlocal! :foldlevel 2)
+          (assert.is_same vals (get-o-lo-go :foldlevel)))))
+    (it "can update option value with string"
+      (fn []
+        (vim.cmd "setlocal signcolumn=no")
+        (let [vals (get-o-lo-go :signcolumn)]
+          (reset-context)
+          (setlocal! :signcolumn :no)
+          (assert.is_same vals (get-o-lo-go :signcolumn)))))
+    (it "can update option value with sequence"
+      (fn []
+        (vim.cmd "setlocal path=/foo,/bar,/baz")
+        (let [vals (get-o-lo-go :path)]
+          (reset-context)
+          (setlocal! :path [:/foo :/bar :/baz])
+          (assert.is_same vals (get-o-lo-go :path)))))
+    (it "can update option value with kv-table"
+      (fn []
+        (vim.cmd "setlocal listchars=eol:a,tab:abc,space:a")
+        (let [vals (get-o-lo-go :listchars)]
+          (reset-context)
+          (setlocal! :listchars {:eol :a :tab :abc :space :a})
+          (assert.is_same vals (get-o-lo-go :listchars)))))
+    (it "can update some option value with nil"
+      (fn []
+        (set vim.opt_local.foldlevel nil)
+        (let [vals (get-o-lo-go :foldlevel)]
+          (reset-context)
+          (setlocal! :foldlevel nil)
+          (assert.is_same vals (get-o-lo-go :foldlevel)))))
+    (it "can update some option value with symbol"
+      (fn []
+        (let [new-val 2]
+          (set vim.opt_local.foldlevel new-val)
+          (let [vals (get-o-lo-go :foldlevel)]
+            (reset-context)
+            (setlocal! :foldlevel new-val)
+            (assert.is_same vals (get-o-lo-go :foldlevel))))))
+    (it "can update some option value with list"
+      (fn []
+        (let [return-val #2]
+          (set vim.opt_local.foldlevel (return-val))
+          (let [vals (get-o-lo-go :foldlevel)]
+            (reset-context)
+            (setlocal! :foldlevel (return-val))
+            (assert.is_same vals (get-o-lo-go :foldlevel))))))
+    (it "can append option value of sequence"
+      (fn []
+        (: vim.opt_local.path :append [:/foo :/bar :/baz])
+        (let [vals (get-o-lo-go :path)]
+          (reset-context)
+          (setlocal! :path+ [:/foo :/bar :/baz])
+          (assert.is_same vals (get-o-lo-go :path)))))
+    (it "can prepend option value of sequence"
+      (fn []
+        (: vim.opt_local.path :prepend [:/foo :/bar :/baz])
+        (let [vals (get-o-lo-go :path)]
+          (reset-context)
+          (setlocal! :path^ [:/foo :/bar :/baz])
+          (assert.is_same vals (get-o-lo-go :path)))))
+    (it "can remove option value of sequence"
+      (fn []
+        (: vim.opt_local.path :remove [:/tmp :/var])
+        (let [vals (get-o-lo-go :path)]
+          (reset-context)
+          (setlocal! :path- [:/tmp :/var])
+          (assert.is_same vals (get-o-lo-go :path)))))
+    (it "can append option value of kv-table"
+      (fn []
+        (: vim.opt_local.listchars :append {:lead :a :trail :b :extends :c})
+        (let [vals (get-o-lo-go :listchars)]
+          (reset-context)
+          (setlocal! :listchars+ {:lead :a :trail :b :extends :c})
+          (assert.is_same vals (get-o-lo-go :listchars)))))
+    (it "can prepend option value of kv-table"
+      (fn []
+        (: vim.opt_local.listchars :prepend {:lead :a :trail :b :extends :c})
+        (let [vals (get-o-lo-go :listchars)]
+          (reset-context)
+          (setlocal! :listchars^ {:lead :a :trail :b :extends :c})
+          (assert.is_same vals (get-o-lo-go :listchars)))))
+    (it "can remove option value of kv-table"
+      (fn []
+        (: vim.opt_local.listchars :remove [:eol :tab])
+        (let [vals (get-o-lo-go :listchars)]
+          (reset-context)
+          (setlocal! :listchars- [:eol :tab])
+          (assert.is_same vals (get-o-lo-go :listchars)))))
+    (describe "with no value"
+      (it "updates option value to `true`"
         (fn []
-          (it "can append flags in sequence"
-            ;; Note: In truth, the formatoptions flag order doesn't matter.
-            (fn []
-              (setlocal! :formatOptions+ [:a :r :B])
-              (assert.is_same {:1 true :2 true :b true :a true :r true :B true}
-                              (get-lo :formatoptions))))
-          (it "can prepend flags in sequence"
-            ;; Note: In truth, the formatoptions flag order doesn't matter.
-            (fn []
-              (setlocal! :formatOptions^ [:a :r :B])
-              (assert.is_same {:1 true :2 true :b true :a true :r true :B true}
-                              (get-lo :formatoptions))))
-          (it "can remove flags in sequence"
-            (fn []
-              (setlocal! :formatOptions- [:b :2])
-              (assert.is_same {:1 true} (get-lo :formatoptions)))))))
-    (describe :setglobal!
-      (fn []
-        (it "can update option value with boolean"
-          (fn []
-            (vim.cmd "setglobal nowrap")
-            (let [vals (get-o-lo-go :wrap)]
-              (reset-context)
-              (setglobal! :wrap false)
-              (assert.is_same vals (get-o-lo-go :wrap)))))
-        (it "can update option value with number"
-          (fn []
-            (vim.cmd "setglobal foldlevel=2")
-            (let [vals (get-o-lo-go :foldlevel)]
-              (reset-context)
-              (setglobal! :foldlevel 2)
-              (assert.is_same vals (get-o-lo-go :foldlevel)))))
-        (it "can update option value with string"
-          (fn []
-            (vim.cmd "setglobal signcolumn=no")
-            (let [vals (get-o-lo-go :signcolumn)]
-              (reset-context)
-              (setglobal! :signcolumn :no)
-              (assert.is_same vals (get-o-lo-go :signcolumn)))))
-        (it "can update option value with sequence"
-          (fn []
-            (vim.cmd "setglobal path=/foo,/bar,/baz")
-            (let [vals (get-o-lo-go :path)]
-              (reset-context)
-              (setglobal! :path [:/foo :/bar :/baz])
-              (assert.is_same vals (get-o-lo-go :path)))))
-        (it "can update option value with kv-table"
-          (fn []
-            (vim.cmd "setglobal listchars=eol:a,tab:abc,space:a")
-            (let [vals (get-o-lo-go :listchars)]
-              (reset-context)
-              (setglobal! :listchars {:eol :a :tab :abc :space :a})
-              (assert.is_same vals (get-o-lo-go :listchars)))))
-        (it "can update some option value with nil"
-          (fn []
-            (set vim.opt_global.foldlevel nil)
-            (let [vals (get-o-lo-go :foldlevel)]
-              (reset-context)
-              (setglobal! :foldlevel nil)
-              (assert.is_same vals (get-o-lo-go :foldlevel)))))
-        (it "can update some option value with symbol"
-          (fn []
-            (let [new-val 2]
-              (set vim.opt_global.foldlevel new-val)
-              (let [vals (get-o-lo-go :foldlevel)]
-                (reset-context)
-                (setglobal! :foldlevel new-val)
-                (assert.is_same vals (get-o-lo-go :foldlevel))))))
-        (it "can update some option value with list"
-          (fn []
-            (let [return-val #2]
-              (set vim.opt_global.foldlevel (return-val))
-              (let [vals (get-o-lo-go :foldlevel)]
-                (reset-context)
-                (setglobal! :foldlevel (return-val))
-                (assert.is_same vals (get-o-lo-go :foldlevel))))))
-        (it "can append option value of sequence"
-          (fn []
-            (: vim.opt_global.path :append [:/foo :/bar :/baz])
-            (let [vals (get-o-lo-go :path)]
-              (reset-context)
-              (setglobal! :path+ [:/foo :/bar :/baz])
-              (assert.is_same vals (get-o-lo-go :path)))))
-        (it "can prepend option value of sequence"
-          (fn []
-            (: vim.opt_global.path :prepend [:/foo :/bar :/baz])
-            (let [vals (get-o-lo-go :path)]
-              (reset-context)
-              (setglobal! :path^ [:/foo :/bar :/baz])
-              (assert.is_same vals (get-o-lo-go :path)))))
-        (it "can remove option value of sequence"
-          (fn []
-            (: vim.opt_global.path :remove [:/tmp :/var])
-            (let [vals (get-o-lo-go :path)]
-              (reset-context)
-              (setglobal! :path- [:/tmp :/var])
-              (assert.is_same vals (get-o-lo-go :path)))))
-        (it "can append option value of kv-table"
-          (fn []
-            (: vim.opt_global.listchars :append
-               {:lead :a :trail :b :extends :c})
-            (let [vals (get-o-lo-go :listchars)]
-              (reset-context)
-              (setglobal! :listchars+ {:lead :a :trail :b :extends :c})
-              (assert.is_same vals (get-o-lo-go :listchars)))))
-        (it "can prepend option value of kv-table"
-          (fn []
-            (: vim.opt_global.listchars :prepend
-               {:lead :a :trail :b :extends :c})
-            (let [vals (get-o-lo-go :listchars)]
-              (reset-context)
-              (setglobal! :listchars^ {:lead :a :trail :b :extends :c})
-              (assert.is_same vals (get-o-lo-go :listchars)))))
-        (it "can remove option value of kv-table"
-          (fn []
-            (: vim.opt_global.listchars :remove [:eol :tab])
-            (let [vals (get-o-lo-go :listchars)]
-              (reset-context)
-              (setglobal! :listchars- [:eol :tab])
-              (assert.is_same vals (get-o-lo-go :listchars))))))
-      (describe "for &l:shortmess"
+          (vim.cmd "setlocal nowrap")
+          (assert.is_false (get-lo :wrap))
+          (setlocal! :wrap)
+          (assert.is_true (get-lo :wrap))))
+      (it "updates value to `true` even when option name is hidden in compile time"
         (fn []
-          (it "can append flags in sequence"
-            ;; Note: In truth, the shortmess flag order doesn't matter.
-            (fn []
-              (setglobal! :shortMess+ [:m :n :r])
-              (assert.is_same {:f true :i true :w true :m true :n true :r true}
-                              (get-lo :shortmess))))
-          (it "can prepend flags in sequence"
-            ;; Note: In truth, the shortmess flag order doesn't matter.
-            (fn []
-              (setglobal! :shortMess^ [:m :n :r])
-              (assert.is_same {:f true :i true :w true :m true :n true :r true}
-                              (get-lo :shortmess))))
-          (it "can remove flags in sequence"
-            (fn []
-              (setglobal! :shortMess- [:i :f])
-              (assert.is_same {:w true} (get-lo :shortmess))))))
-      (describe "with no value"
+          (vim.cmd "setlocal nowrap")
+          (assert.is_false (get-lo :wrap))
+          (let [name :wrap]
+            (setlocal! name)
+            (assert.is_true (get-lo name))))))
+    (describe "for &l:formatoptions"
+      (it "can append flags in sequence"
+        ;; Note: In truth, the formatoptions flag order doesn't matter.
         (fn []
-          (it "updates option value to `true`"
-            (fn []
-              (vim.cmd "setglobal nowrap")
-              (assert.is_false (get-go :wrap))
-              (setglobal! :wrap)
-              (assert.is_true (get-go :wrap))))
-          (it "updates value to `true` even when option name is hidden in compile time"
-            (fn []
-              (vim.cmd "setglobal nowrap")
-              (assert.is_false (get-go :wrap))
-              (let [name :wrap]
-                (setglobal! name)
-                (assert.is_true (get-go name))))))))
-    (describe :bo!
+          (setlocal! :formatOptions+ [:a :r :B])
+          (assert.is_same {:1 true :2 true :b true :a true :r true :B true}
+                          (get-lo :formatoptions))))
+      (it "can prepend flags in sequence"
+        ;; Note: In truth, the formatoptions flag order doesn't matter.
+        (fn []
+          (setlocal! :formatOptions^ [:a :r :B])
+          (assert.is_same {:1 true :2 true :b true :a true :r true :B true}
+                          (get-lo :formatoptions))))
+      (it "can remove flags in sequence"
+        (fn []
+          (setlocal! :formatOptions- [:b :2])
+          (assert.is_same {:1 true} (get-lo :formatoptions))))))
+  (describe :setglobal!
+    (it "can update option value with boolean"
       (fn []
-        (it "can update option value with boolean"
-          (fn []
-            (tset vim.bo :expandtab false)
-            (let [vals (get-o-lo-go :expandtab)]
-              (reset-context)
-              (bo! :expandtab false)
-              (assert.is_same vals (get-o-lo-go :expandtab)))))
-        (it "can update option value with number"
-          (fn []
-            (tset vim.bo :tabstop 2)
-            (let [vals (get-o-lo-go :tabstop)]
-              (reset-context)
-              (bo! :tabstop 2)
-              (assert.is_same vals (get-o-lo-go :tabstop)))))
-        (it "can update option value with string"
-          (fn []
-            (tset vim.bo :omnifunc :abc)
-            (let [vals (get-o-lo-go :omnifunc)]
-              (reset-context)
-              (bo! :omnifunc :abc)
-              (assert.is_same vals (get-o-lo-go :omnifunc)))))
-        (it "can update option value with sequence"
-          (fn []
-            (tset vim.bo :path "/foo,/bar,/baz")
-            (let [vals (get-o-lo-go :path)]
-              (reset-context)
-              (bo! :path [:/foo :/bar :/baz])
-              (assert.is_same vals (get-o-lo-go :path)))))
-        (it "can update option value with kv-table"
-          (fn []
-            (tset vim.bo :matchpairs "a:A,b:B,c:C")
-            (let [vals (get-o-lo-go :matchpairs)]
-              (reset-context)
-              (bo! :matchPairs {:a :A :b :B :c :C})
-              (assert.is_same vals (get-o-lo-go :matchpairs)))))
-        (it "can update some option value with nil"
-          (fn []
-            (set vim.bo.tabstop nil)
-            (let [vals (get-o-lo-go :tabstop)]
-              (reset-context)
-              (bo! :tabstop nil)
-              (assert.is_same vals (get-o-lo-go :tabstop)))))
-        (it "can update some option value with symbol"
-          (fn []
-            (let [new-val 2]
-              (set vim.bo.tabstop new-val)
-              (let [vals (get-o-lo-go :tabstop)]
-                (reset-context)
-                (bo! :tabstop new-val)
-                (assert.is_same vals (get-o-lo-go :tabstop))))))
-        (it "can update some option value with list"
-          (fn []
-            (let [return-val #2]
-              (set vim.bo.tabstop (return-val))
-              (let [vals (get-o-lo-go :tabstop)]
-                (reset-context)
-                (bo! :tabstop (return-val))
-                (assert.is_same vals (get-o-lo-go :tabstop))))))
-        (describe "with bufnr"
-          (it "can update option value with boolean"
-            (fn []
-              (let [buf (vim.api.nvim_get_current_buf)]
-                (reset-context)
-                (bo! buf :expandtab false)
-                (assert.is_false (. vim.bo buf :expandtab)))))
-          (it "can update option value with number"
-            (fn []
-              (let [buf (vim.api.nvim_get_current_buf)]
-                (reset-context)
-                (bo! buf :tabstop 2)
-                (assert.is_same 2 (. vim.bo buf :tabstop)))))
-          (it "can update option value with string"
-            (fn []
-              (let [buf (vim.api.nvim_get_current_buf)]
-                (reset-context)
-                (bo! buf :omnifunc :abc)
-                (assert.is_same :abc (. vim.bo buf :omnifunc)))))
-          (it "can update option value with sequence"
-            (fn []
-              (let [buf (vim.api.nvim_get_current_buf)]
-                (reset-context)
-                (bo! buf :path [:/foo :/bar :/baz])
-                (assert.is_same "/foo,/bar,/baz" (. vim.bo buf :path)))))
-          (it "can update option value with kv-table"
-            (fn []
-              (let [buf (vim.api.nvim_get_current_buf)]
-                (reset-context)
-                (bo! buf :matchPairs {:a :A :b :B :c :C})
-                (assert.is_same "a:A,b:B,c:C" (. vim.bo buf :matchpairs)))))
-          (it "can update some option value with nil"
-            (fn []
-              (let [buf (vim.api.nvim_get_current_buf)]
-                (reset-context)
-                (bo! buf :tabstop nil)
-                (assert.is_same vim.go.tabstop (. vim.bo buf :tabstop)))))
-          (it "can update some option value with symbol"
-            (fn []
-              (let [buf (vim.api.nvim_get_current_buf)
-                    new-val 2]
-                (reset-context)
-                (bo! buf :tabstop new-val)
-                (assert.is_same new-val (. vim.bo buf :tabstop)))))
-          (it "can update some option value with list"
-            (fn []
-              (let [buf (vim.api.nvim_get_current_buf)
-                    new-val 2
-                    return-val #new-val]
-                (reset-context)
-                (bo! buf :tabstop (return-val))
-                (assert.is_same new-val (. vim.bo buf :tabstop))))))))
-    (describe :wo!
+        (vim.cmd "setglobal nowrap")
+        (let [vals (get-o-lo-go :wrap)]
+          (reset-context)
+          (setglobal! :wrap false)
+          (assert.is_same vals (get-o-lo-go :wrap)))))
+    (it "can update option value with number"
       (fn []
-        (it "can update option value with boolean"
-          (fn []
-            (tset vim.wo :wrap false)
-            (let [vals (get-o-lo-go :wrap)]
-              (reset-context)
-              (wo! :wrap false)
-              (assert.is_same vals (get-o-lo-go :wrap)))))
-        (it "can update option value with number"
-          (fn []
-            (tset vim.wo :foldlevel 2)
-            (let [vals (get-o-lo-go :foldlevel)]
-              (reset-context)
-              (wo! :foldlevel 2)
-              (assert.is_same vals (get-o-lo-go :foldlevel)))))
-        (it "can update option value with string"
-          (fn []
-            (tset vim.wo :signcolumn :no)
-            (let [vals (get-o-lo-go :signcolumn)]
-              (reset-context)
-              (wo! :signcolumn :no)
-              (assert.is_same vals (get-o-lo-go :signcolumn)))))
-        (it "can update option value with sequence"
-          (fn []
-            (tset vim.wo :colorcolumn "80,81,82")
-            (let [vals (get-o-lo-go :colorcolumn)]
-              (reset-context)
-              (wo! :colorcolumn [:80 :81 :82])
-              (assert.is_same vals (get-o-lo-go :colorcolumn)))))
-        (it "can update option value with kv-table"
-          (fn []
-            (tset vim.wo :listchars "eol:a,tab:abc,space:a")
-            (let [vals (get-o-lo-go :listchars)]
-              (reset-context)
-              (wo! :listchars {:eol :a :tab :abc :space :a})
-              (assert.is_same vals (get-o-lo-go :listchars)))))
-        (it "can update some option value with nil"
-          (fn []
-            (set vim.wo.foldlevel nil)
-            (let [vals (get-o-lo-go :foldlevel)]
-              (reset-context)
-              (wo! :foldlevel nil)
-              (assert.is_same vals (get-o-lo-go :foldlevel)))))
-        (it "can update some option value with symbol"
-          (fn []
-            (let [new-val 2]
-              (set vim.wo.foldlevel new-val)
-              (let [vals (get-o-lo-go :foldlevel)]
-                (reset-context)
-                (wo! :foldlevel new-val)
-                (assert.is_same vals (get-o-lo-go :foldlevel))))))
-        (it "can update some option value with list"
-          (fn []
-            (let [return-val #2]
-              (set vim.wo.foldlevel (return-val))
-              (let [vals (get-o-lo-go :foldlevel)]
-                (reset-context)
-                (wo! :foldlevel (return-val))
-                (assert.is_same vals (get-o-lo-go :foldlevel))))))
-        (describe "with win-id"
-          (it "can update option value with woolean"
-            (fn []
-              (let [win (vim.api.nvim_get_current_win)]
-                (vim.cmd.new)
-                (wo! win :wrap false)
-                (assert.is_false (. vim.wo win :wrap)))))
-          (it "can update option value with number"
-            (fn []
-              (let [win (vim.api.nvim_get_current_win)]
-                (vim.cmd.new)
-                (wo! win :foldlevel 2)
-                (assert.is_same 2 (. vim.wo win :foldlevel)))))
-          (it "can update option value with string"
-            (fn []
-              (let [win (vim.api.nvim_get_current_win)]
-                (vim.cmd.new)
-                (wo! win :signcolumn :no)
-                (assert.is_same :no (. vim.wo win :signcolumn)))))
-          (it "can update option value with sequence"
-            (fn []
-              (let [win (vim.api.nvim_get_current_win)]
-                (vim.cmd.new)
-                (wo! win :colorcolumn [:80 :81 :82])
-                (assert.is_same "80,81,82" (. vim.wo win :colorcolumn)))))
-          (it "can update option value with kv-table"
-            (fn []
-              (let [win (vim.api.nvim_get_current_win)]
-                (vim.cmd.new)
-                (wo! win :listchars {:eol :a :tab :abc :space :a})
-                (assert.is_same "eol:a,tab:abc,space:a"
-                                (. vim.wo win :listchars)))))
-          (it "can update some option value with nil"
-            (fn []
-              (let [win (vim.api.nvim_get_current_win)]
-                (vim.cmd.new)
-                (wo! win :foldlevel nil)
-                (assert.is_same vim.go.foldlevel (. vim.wo win :foldlevel)))))
-          (it "can update some option value with symbol"
-            (fn []
-              (let [win (vim.api.nvim_get_current_win)
-                    new-val 2]
-                (vim.cmd.new)
-                (wo! win :foldlevel new-val)
-                (assert.is_same new-val (. vim.wo win :foldlevel)))))
-          (it "can update some option value with list"
-            (fn []
-              (let [win (vim.api.nvim_get_current_win)
-                    new-val 2
-                    return-val #new-val]
-                (vim.cmd.new)
-                (wo! win :foldlevel (return-val))
-                (assert.is_same new-val (. vim.wo win :foldlevel))))))))
-    (describe :set+
+        (vim.cmd "setglobal foldlevel=2")
+        (let [vals (get-o-lo-go :foldlevel)]
+          (reset-context)
+          (setglobal! :foldlevel 2)
+          (assert.is_same vals (get-o-lo-go :foldlevel)))))
+    (it "can update option value with string"
       (fn []
-        (it "appends option value of sequence"
-          #(let [name :path
-                 assigned-val [:/foo :/bar :/baz]]
-             (-> (. vim.opt name) (: :append assigned-val))
-             (let [expected-vals (get-o-lo-go name)]
-               (reset-context)
-               (set+ name assigned-val)
-               (assert.is_same expected-vals (get-o-lo-go name)))))
-        (it "appends option value of kv-table"
-          #(let [name :listchars
-                 assigned-val {:lead :a :trail :b :extends :c}]
-             (-> (. vim.opt name) (: :append assigned-val))
-             (let [expected-vals (get-o-lo-go name)]
-               (reset-context)
-               (set+ name assigned-val)
-               (assert.is_same expected-vals (get-o-lo-go name)))))))
-    (describe :set^
+        (vim.cmd "setglobal signcolumn=no")
+        (let [vals (get-o-lo-go :signcolumn)]
+          (reset-context)
+          (setglobal! :signcolumn :no)
+          (assert.is_same vals (get-o-lo-go :signcolumn)))))
+    (it "can update option value with sequence"
       (fn []
-        (it "prepends option value of sequence"
-          #(let [name :path
-                 assigned-val [:/foo :/bar :/baz]]
-             (-> (. vim.opt name) (: :prepend assigned-val))
-             (let [expected-vals (get-o-lo-go name)]
-               (reset-context)
-               (set^ name assigned-val)
-               (assert.is_same expected-vals (get-o-lo-go name)))))
-        (it "prepends option value of kv-table"
-          #(let [name :listchars
-                 assigned-val {:lead :a :trail :b :extends :c}]
-             (-> (. vim.opt name) (: :prepend assigned-val))
-             (let [expected-vals (get-o-lo-go name)]
-               (reset-context)
-               (set^ name assigned-val)
-               (assert.is_same expected-vals (get-o-lo-go name)))))))
-    (describe :set-
+        (vim.cmd "setglobal path=/foo,/bar,/baz")
+        (let [vals (get-o-lo-go :path)]
+          (reset-context)
+          (setglobal! :path [:/foo :/bar :/baz])
+          (assert.is_same vals (get-o-lo-go :path)))))
+    (it "can update option value with kv-table"
       (fn []
-        (it "removes option value of sequence"
-          #(let [name :path
-                 assigned-val [:/tmp :/var]]
-             (-> (. vim.opt name) (: :remove assigned-val))
-             (let [expected-vals (get-o-lo-go name)]
-               (reset-context)
-               (set- name assigned-val)
-               (assert.is_same expected-vals (get-o-lo-go name)))))
-        (it "removes option value of kv-table"
-          #(let [name :listchars
-                 assigned-val {:lead :a :trail :b :extends :c}]
-             (-> (. vim.opt name) (: :remove assigned-val))
-             (let [expected-vals (get-o-lo-go name)]
-               (reset-context)
-               (set- name assigned-val)
-               (assert.is_same expected-vals (get-o-lo-go name)))))))))
+        (vim.cmd "setglobal listchars=eol:a,tab:abc,space:a")
+        (let [vals (get-o-lo-go :listchars)]
+          (reset-context)
+          (setglobal! :listchars {:eol :a :tab :abc :space :a})
+          (assert.is_same vals (get-o-lo-go :listchars)))))
+    (it "can update some option value with nil"
+      (fn []
+        (set vim.opt_global.foldlevel nil)
+        (let [vals (get-o-lo-go :foldlevel)]
+          (reset-context)
+          (setglobal! :foldlevel nil)
+          (assert.is_same vals (get-o-lo-go :foldlevel)))))
+    (it "can update some option value with symbol"
+      (fn []
+        (let [new-val 2]
+          (set vim.opt_global.foldlevel new-val)
+          (let [vals (get-o-lo-go :foldlevel)]
+            (reset-context)
+            (setglobal! :foldlevel new-val)
+            (assert.is_same vals (get-o-lo-go :foldlevel))))))
+    (it "can update some option value with list"
+      (fn []
+        (let [return-val #2]
+          (set vim.opt_global.foldlevel (return-val))
+          (let [vals (get-o-lo-go :foldlevel)]
+            (reset-context)
+            (setglobal! :foldlevel (return-val))
+            (assert.is_same vals (get-o-lo-go :foldlevel))))))
+    (it "can append option value of sequence"
+      (fn []
+        (: vim.opt_global.path :append [:/foo :/bar :/baz])
+        (let [vals (get-o-lo-go :path)]
+          (reset-context)
+          (setglobal! :path+ [:/foo :/bar :/baz])
+          (assert.is_same vals (get-o-lo-go :path)))))
+    (it "can prepend option value of sequence"
+      (fn []
+        (: vim.opt_global.path :prepend [:/foo :/bar :/baz])
+        (let [vals (get-o-lo-go :path)]
+          (reset-context)
+          (setglobal! :path^ [:/foo :/bar :/baz])
+          (assert.is_same vals (get-o-lo-go :path)))))
+    (it "can remove option value of sequence"
+      (fn []
+        (: vim.opt_global.path :remove [:/tmp :/var])
+        (let [vals (get-o-lo-go :path)]
+          (reset-context)
+          (setglobal! :path- [:/tmp :/var])
+          (assert.is_same vals (get-o-lo-go :path)))))
+    (it "can append option value of kv-table"
+      (fn []
+        (: vim.opt_global.listchars :append {:lead :a :trail :b :extends :c})
+        (let [vals (get-o-lo-go :listchars)]
+          (reset-context)
+          (setglobal! :listchars+ {:lead :a :trail :b :extends :c})
+          (assert.is_same vals (get-o-lo-go :listchars)))))
+    (it "can prepend option value of kv-table"
+      (fn []
+        (: vim.opt_global.listchars :prepend {:lead :a :trail :b :extends :c})
+        (let [vals (get-o-lo-go :listchars)]
+          (reset-context)
+          (setglobal! :listchars^ {:lead :a :trail :b :extends :c})
+          (assert.is_same vals (get-o-lo-go :listchars)))))
+    (it "can remove option value of kv-table"
+      (fn []
+        (: vim.opt_global.listchars :remove [:eol :tab])
+        (let [vals (get-o-lo-go :listchars)]
+          (reset-context)
+          (setglobal! :listchars- [:eol :tab])
+          (assert.is_same vals (get-o-lo-go :listchars)))))
+    (describe "for &l:shortmess"
+      (it "can append flags in sequence"
+        ;; Note: In truth, the shortmess flag order doesn't matter.
+        (fn []
+          (setglobal! :shortMess+ [:m :n :r])
+          (assert.is_same {:f true :i true :w true :m true :n true :r true}
+                          (get-lo :shortmess))))
+      (it "can prepend flags in sequence"
+        ;; Note: In truth, the shortmess flag order doesn't matter.
+        (fn []
+          (setglobal! :shortMess^ [:m :n :r])
+          (assert.is_same {:f true :i true :w true :m true :n true :r true}
+                          (get-lo :shortmess))))
+      (it "can remove flags in sequence"
+        (fn []
+          (setglobal! :shortMess- [:i :f])
+          (assert.is_same {:w true} (get-lo :shortmess)))))
+    (describe "with no value"
+      (it "updates option value to `true`"
+        (fn []
+          (vim.cmd "setglobal nowrap")
+          (assert.is_false (get-go :wrap))
+          (setglobal! :wrap)
+          (assert.is_true (get-go :wrap))))
+      (it "updates value to `true` even when option name is hidden in compile time"
+        (fn []
+          (vim.cmd "setglobal nowrap")
+          (assert.is_false (get-go :wrap))
+          (let [name :wrap]
+            (setglobal! name)
+            (assert.is_true (get-go name)))))))
+  (describe :bo!
+    (it "can update option value with boolean"
+      (fn []
+        (tset vim.bo :expandtab false)
+        (let [vals (get-o-lo-go :expandtab)]
+          (reset-context)
+          (bo! :expandtab false)
+          (assert.is_same vals (get-o-lo-go :expandtab)))))
+    (it "can update option value with number"
+      (fn []
+        (tset vim.bo :tabstop 2)
+        (let [vals (get-o-lo-go :tabstop)]
+          (reset-context)
+          (bo! :tabstop 2)
+          (assert.is_same vals (get-o-lo-go :tabstop)))))
+    (it "can update option value with string"
+      (fn []
+        (tset vim.bo :omnifunc :abc)
+        (let [vals (get-o-lo-go :omnifunc)]
+          (reset-context)
+          (bo! :omnifunc :abc)
+          (assert.is_same vals (get-o-lo-go :omnifunc)))))
+    (it "can update option value with sequence"
+      (fn []
+        (tset vim.bo :path "/foo,/bar,/baz")
+        (let [vals (get-o-lo-go :path)]
+          (reset-context)
+          (bo! :path [:/foo :/bar :/baz])
+          (assert.is_same vals (get-o-lo-go :path)))))
+    (it "can update option value with kv-table"
+      (fn []
+        (tset vim.bo :matchpairs "a:A,b:B,c:C")
+        (let [vals (get-o-lo-go :matchpairs)]
+          (reset-context)
+          (bo! :matchPairs {:a :A :b :B :c :C})
+          (assert.is_same vals (get-o-lo-go :matchpairs)))))
+    (it "can update some option value with nil"
+      (fn []
+        (set vim.bo.tabstop nil)
+        (let [vals (get-o-lo-go :tabstop)]
+          (reset-context)
+          (bo! :tabstop nil)
+          (assert.is_same vals (get-o-lo-go :tabstop)))))
+    (it "can update some option value with symbol"
+      (fn []
+        (let [new-val 2]
+          (set vim.bo.tabstop new-val)
+          (let [vals (get-o-lo-go :tabstop)]
+            (reset-context)
+            (bo! :tabstop new-val)
+            (assert.is_same vals (get-o-lo-go :tabstop))))))
+    (it "can update some option value with list"
+      (fn []
+        (let [return-val #2]
+          (set vim.bo.tabstop (return-val))
+          (let [vals (get-o-lo-go :tabstop)]
+            (reset-context)
+            (bo! :tabstop (return-val))
+            (assert.is_same vals (get-o-lo-go :tabstop))))))
+    (describe "with bufnr"
+      (it "can update option value with boolean"
+        (fn []
+          (let [buf (vim.api.nvim_get_current_buf)]
+            (reset-context)
+            (bo! buf :expandtab false)
+            (assert.is_false (. vim.bo buf :expandtab)))))
+      (it "can update option value with number"
+        (fn []
+          (let [buf (vim.api.nvim_get_current_buf)]
+            (reset-context)
+            (bo! buf :tabstop 2)
+            (assert.is_same 2 (. vim.bo buf :tabstop)))))
+      (it "can update option value with string"
+        (fn []
+          (let [buf (vim.api.nvim_get_current_buf)]
+            (reset-context)
+            (bo! buf :omnifunc :abc)
+            (assert.is_same :abc (. vim.bo buf :omnifunc)))))
+      (it "can update option value with sequence"
+        (fn []
+          (let [buf (vim.api.nvim_get_current_buf)]
+            (reset-context)
+            (bo! buf :path [:/foo :/bar :/baz])
+            (assert.is_same "/foo,/bar,/baz" (. vim.bo buf :path)))))
+      (it "can update option value with kv-table"
+        (fn []
+          (let [buf (vim.api.nvim_get_current_buf)]
+            (reset-context)
+            (bo! buf :matchPairs {:a :A :b :B :c :C})
+            (assert.is_same "a:A,b:B,c:C" (. vim.bo buf :matchpairs)))))
+      (it "can update some option value with nil"
+        (fn []
+          (let [buf (vim.api.nvim_get_current_buf)]
+            (reset-context)
+            (bo! buf :tabstop nil)
+            (assert.is_same vim.go.tabstop (. vim.bo buf :tabstop)))))
+      (it "can update some option value with symbol"
+        (fn []
+          (let [buf (vim.api.nvim_get_current_buf)
+                new-val 2]
+            (reset-context)
+            (bo! buf :tabstop new-val)
+            (assert.is_same new-val (. vim.bo buf :tabstop)))))
+      (it "can update some option value with list"
+        (fn []
+          (let [buf (vim.api.nvim_get_current_buf)
+                new-val 2
+                return-val #new-val]
+            (reset-context)
+            (bo! buf :tabstop (return-val))
+            (assert.is_same new-val (. vim.bo buf :tabstop)))))))
+  (describe :wo!
+    (it "can update option value with boolean"
+      (fn []
+        (tset vim.wo :wrap false)
+        (let [vals (get-o-lo-go :wrap)]
+          (reset-context)
+          (wo! :wrap false)
+          (assert.is_same vals (get-o-lo-go :wrap)))))
+    (it "can update option value with number"
+      (fn []
+        (tset vim.wo :foldlevel 2)
+        (let [vals (get-o-lo-go :foldlevel)]
+          (reset-context)
+          (wo! :foldlevel 2)
+          (assert.is_same vals (get-o-lo-go :foldlevel)))))
+    (it "can update option value with string"
+      (fn []
+        (tset vim.wo :signcolumn :no)
+        (let [vals (get-o-lo-go :signcolumn)]
+          (reset-context)
+          (wo! :signcolumn :no)
+          (assert.is_same vals (get-o-lo-go :signcolumn)))))
+    (it "can update option value with sequence"
+      (fn []
+        (tset vim.wo :colorcolumn "80,81,82")
+        (let [vals (get-o-lo-go :colorcolumn)]
+          (reset-context)
+          (wo! :colorcolumn [:80 :81 :82])
+          (assert.is_same vals (get-o-lo-go :colorcolumn)))))
+    (it "can update option value with kv-table"
+      (fn []
+        (tset vim.wo :listchars "eol:a,tab:abc,space:a")
+        (let [vals (get-o-lo-go :listchars)]
+          (reset-context)
+          (wo! :listchars {:eol :a :tab :abc :space :a})
+          (assert.is_same vals (get-o-lo-go :listchars)))))
+    (it "can update some option value with nil"
+      (fn []
+        (set vim.wo.foldlevel nil)
+        (let [vals (get-o-lo-go :foldlevel)]
+          (reset-context)
+          (wo! :foldlevel nil)
+          (assert.is_same vals (get-o-lo-go :foldlevel)))))
+    (it "can update some option value with symbol"
+      (fn []
+        (let [new-val 2]
+          (set vim.wo.foldlevel new-val)
+          (let [vals (get-o-lo-go :foldlevel)]
+            (reset-context)
+            (wo! :foldlevel new-val)
+            (assert.is_same vals (get-o-lo-go :foldlevel))))))
+    (it "can update some option value with list"
+      (fn []
+        (let [return-val #2]
+          (set vim.wo.foldlevel (return-val))
+          (let [vals (get-o-lo-go :foldlevel)]
+            (reset-context)
+            (wo! :foldlevel (return-val))
+            (assert.is_same vals (get-o-lo-go :foldlevel))))))
+    (describe "with win-id"
+      (it "can update option value with woolean"
+        (fn []
+          (let [win (vim.api.nvim_get_current_win)]
+            (vim.cmd.new)
+            (wo! win :wrap false)
+            (assert.is_false (. vim.wo win :wrap)))))
+      (it "can update option value with number"
+        (fn []
+          (let [win (vim.api.nvim_get_current_win)]
+            (vim.cmd.new)
+            (wo! win :foldlevel 2)
+            (assert.is_same 2 (. vim.wo win :foldlevel)))))
+      (it "can update option value with string"
+        (fn []
+          (let [win (vim.api.nvim_get_current_win)]
+            (vim.cmd.new)
+            (wo! win :signcolumn :no)
+            (assert.is_same :no (. vim.wo win :signcolumn)))))
+      (it "can update option value with sequence"
+        (fn []
+          (let [win (vim.api.nvim_get_current_win)]
+            (vim.cmd.new)
+            (wo! win :colorcolumn [:80 :81 :82])
+            (assert.is_same "80,81,82" (. vim.wo win :colorcolumn)))))
+      (it "can update option value with kv-table"
+        (fn []
+          (let [win (vim.api.nvim_get_current_win)]
+            (vim.cmd.new)
+            (wo! win :listchars {:eol :a :tab :abc :space :a})
+            (assert.is_same "eol:a,tab:abc,space:a" (. vim.wo win :listchars)))))
+      (it "can update some option value with nil"
+        (fn []
+          (let [win (vim.api.nvim_get_current_win)]
+            (vim.cmd.new)
+            (wo! win :foldlevel nil)
+            (assert.is_same vim.go.foldlevel (. vim.wo win :foldlevel)))))
+      (it "can update some option value with symbol"
+        (fn []
+          (let [win (vim.api.nvim_get_current_win)
+                new-val 2]
+            (vim.cmd.new)
+            (wo! win :foldlevel new-val)
+            (assert.is_same new-val (. vim.wo win :foldlevel)))))
+      (it "can update some option value with list"
+        (fn []
+          (let [win (vim.api.nvim_get_current_win)
+                new-val 2
+                return-val #new-val]
+            (vim.cmd.new)
+            (wo! win :foldlevel (return-val))
+            (assert.is_same new-val (. vim.wo win :foldlevel)))))))
+  (describe :set+
+    (it "appends option value of sequence"
+      #(let [name :path
+             assigned-val [:/foo :/bar :/baz]]
+         (-> (. vim.opt name) (: :append assigned-val))
+         (let [expected-vals (get-o-lo-go name)]
+           (reset-context)
+           (set+ name assigned-val)
+           (assert.is_same expected-vals (get-o-lo-go name)))))
+    (it "appends option value of kv-table"
+      #(let [name :listchars
+             assigned-val {:lead :a :trail :b :extends :c}]
+         (-> (. vim.opt name) (: :append assigned-val))
+         (let [expected-vals (get-o-lo-go name)]
+           (reset-context)
+           (set+ name assigned-val)
+           (assert.is_same expected-vals (get-o-lo-go name))))))
+  (describe :set^
+    (it "prepends option value of sequence"
+      #(let [name :path
+             assigned-val [:/foo :/bar :/baz]]
+         (-> (. vim.opt name) (: :prepend assigned-val))
+         (let [expected-vals (get-o-lo-go name)]
+           (reset-context)
+           (set^ name assigned-val)
+           (assert.is_same expected-vals (get-o-lo-go name)))))
+    (it "prepends option value of kv-table"
+      #(let [name :listchars
+             assigned-val {:lead :a :trail :b :extends :c}]
+         (-> (. vim.opt name) (: :prepend assigned-val))
+         (let [expected-vals (get-o-lo-go name)]
+           (reset-context)
+           (set^ name assigned-val)
+           (assert.is_same expected-vals (get-o-lo-go name))))))
+  (describe :set-
+    (it "removes option value of sequence"
+      #(let [name :path
+             assigned-val [:/tmp :/var]]
+         (-> (. vim.opt name) (: :remove assigned-val))
+         (let [expected-vals (get-o-lo-go name)]
+           (reset-context)
+           (set- name assigned-val)
+           (assert.is_same expected-vals (get-o-lo-go name)))))
+    (it "removes option value of kv-table"
+      #(let [name :listchars
+             assigned-val {:lead :a :trail :b :extends :c}]
+         (-> (. vim.opt name) (: :remove assigned-val))
+         (let [expected-vals (get-o-lo-go name)]
+           (reset-context)
+           (set- name assigned-val)
+           (assert.is_same expected-vals (get-o-lo-go name)))))))

--- a/tests/spec/option_spec.fnl
+++ b/tests/spec/option_spec.fnl
@@ -1,4 +1,4 @@
-(import-macros {: describe} :_busted_macros)
+(import-macros {: describe : it} :_busted_macros)
 (import-macros {: set!
                 : set+
                 : set^
@@ -69,661 +69,574 @@
   (before_each reset-context)
   (describe :set!
     (it "is case-insensitive at option name"
-      (fn []
-        (vim.cmd "set foldlevel=2")
-        (let [vals (get-o-lo-go :foldlevel)]
-          (reset-context)
-          (set! :foldLevel 2)
-          (assert.is_same vals (get-o-lo-go :foldlevel)))))
+      (vim.cmd "set foldlevel=2")
+      (let [vals (get-o-lo-go :foldlevel)]
+        (reset-context)
+        (set! :foldLevel 2)
+        (assert.is_same vals (get-o-lo-go :foldlevel))))
     (it "can update option value with boolean"
-      (fn []
-        (vim.cmd "set nowrap")
-        (let [vals (get-o-lo-go :wrap)]
-          (reset-context)
-          (set! :wrap false)
-          (assert.is_same vals (get-o-lo-go :wrap)))))
+      (vim.cmd "set nowrap")
+      (let [vals (get-o-lo-go :wrap)]
+        (reset-context)
+        (set! :wrap false)
+        (assert.is_same vals (get-o-lo-go :wrap))))
     (it "can update option value with number"
-      (fn []
-        (vim.cmd "set foldlevel=2")
-        (let [vals (get-o-lo-go :foldlevel)]
-          (reset-context)
-          (set! :foldlevel 2)
-          (assert.is_same vals (get-o-lo-go :foldlevel)))))
+      (vim.cmd "set foldlevel=2")
+      (let [vals (get-o-lo-go :foldlevel)]
+        (reset-context)
+        (set! :foldlevel 2)
+        (assert.is_same vals (get-o-lo-go :foldlevel))))
     (it "can update option value with string"
-      (fn []
-        (vim.cmd "set signcolumn=no")
-        (let [vals (get-o-lo-go :signcolumn)]
-          (reset-context)
-          (set! :signcolumn :no)
-          (assert.is_same vals (get-o-lo-go :signcolumn)))))
+      (vim.cmd "set signcolumn=no")
+      (let [vals (get-o-lo-go :signcolumn)]
+        (reset-context)
+        (set! :signcolumn :no)
+        (assert.is_same vals (get-o-lo-go :signcolumn))))
     (it "can update option value with sequence"
-      (fn []
-        (vim.cmd "set path=/foo,/bar,/baz")
-        (let [vals (get-o-lo-go :path)]
-          (reset-context)
-          (set! :path [:/foo :/bar :/baz])
-          (assert.is_same vals (get-o-lo-go :path)))))
+      (vim.cmd "set path=/foo,/bar,/baz")
+      (let [vals (get-o-lo-go :path)]
+        (reset-context)
+        (set! :path [:/foo :/bar :/baz])
+        (assert.is_same vals (get-o-lo-go :path))))
     (it "can update option value with kv-table"
-      (fn []
-        (vim.cmd "set listchars=eol:a,tab:abc,space:a")
-        (let [vals (get-o-lo-go :listchars)]
-          (reset-context)
-          (set! :listchars {:eol :a :tab :abc :space :a})
-          (assert.is_same vals (get-o-lo-go :listchars)))))
+      (vim.cmd "set listchars=eol:a,tab:abc,space:a")
+      (let [vals (get-o-lo-go :listchars)]
+        (reset-context)
+        (set! :listchars {:eol :a :tab :abc :space :a})
+        (assert.is_same vals (get-o-lo-go :listchars))))
     (it "can update some option value with nil"
-      (fn []
-        (set vim.opt.foldlevel nil)
+      (set vim.opt.foldlevel nil)
+      (let [vals (get-o-lo-go :foldlevel)]
+        (reset-context)
+        (set! :foldlevel nil)
+        (assert.is_same vals (get-o-lo-go :foldlevel))))
+    (it "can update some option value with symbol"
+      (let [new-val 2]
+        (set vim.opt.foldlevel new-val)
         (let [vals (get-o-lo-go :foldlevel)]
           (reset-context)
-          (set! :foldlevel nil)
+          (set! :foldlevel new-val)
           (assert.is_same vals (get-o-lo-go :foldlevel)))))
-    (it "can update some option value with symbol"
-      (fn []
-        (let [new-val 2]
-          (set vim.opt.foldlevel new-val)
-          (let [vals (get-o-lo-go :foldlevel)]
-            (reset-context)
-            (set! :foldlevel new-val)
-            (assert.is_same vals (get-o-lo-go :foldlevel))))))
     (it "can update some option value with list"
-      (fn []
-        (let [return-val #2]
-          (set vim.opt.foldlevel (return-val))
-          (let [vals (get-o-lo-go :foldlevel)]
-            (reset-context)
-            (set! :foldlevel (return-val))
-            (assert.is_same vals (get-o-lo-go :foldlevel))
-            (assert.is_same vals (get-o-lo-go :foldlevel))))))
+      (let [return-val #2]
+        (set vim.opt.foldlevel (return-val))
+        (let [vals (get-o-lo-go :foldlevel)]
+          (reset-context)
+          (set! :foldlevel (return-val))
+          (assert.is_same vals (get-o-lo-go :foldlevel))
+          (assert.is_same vals (get-o-lo-go :foldlevel)))))
     (it "can append option value of sequence"
-      (fn []
-        (vim.cmd "set path+=/foo,/bar,/baz")
-        (let [vals (get-o-lo-go :path)]
-          (reset-context)
-          (set! :path+ [:/foo :/bar :/baz])
-          (assert.is_same vals (get-o-lo-go :path)))))
+      (vim.cmd "set path+=/foo,/bar,/baz")
+      (let [vals (get-o-lo-go :path)]
+        (reset-context)
+        (set! :path+ [:/foo :/bar :/baz])
+        (assert.is_same vals (get-o-lo-go :path))))
     (it "can prepend option value of sequence"
-      (fn []
-        (vim.cmd "set path^=/foo,/bar,/baz")
-        (let [vals (get-o-lo-go :path)]
-          (reset-context)
-          (set! :path^ [:/foo :/bar :/baz])
-          (assert.is_same vals (get-o-lo-go :path)))))
+      (vim.cmd "set path^=/foo,/bar,/baz")
+      (let [vals (get-o-lo-go :path)]
+        (reset-context)
+        (set! :path^ [:/foo :/bar :/baz])
+        (assert.is_same vals (get-o-lo-go :path))))
     (it "can remove option value of sequence"
-      (fn []
-        (vim.cmd "set path-=/tmp,/var")
-        (let [vals (get-o-lo-go :path)]
-          (reset-context)
-          (set! :path- [:/tmp :/var])
-          (assert.is_same vals (get-o-lo-go :path)))))
+      (vim.cmd "set path-=/tmp,/var")
+      (let [vals (get-o-lo-go :path)]
+        (reset-context)
+        (set! :path- [:/tmp :/var])
+        (assert.is_same vals (get-o-lo-go :path))))
     (it "can append option value of kv-table"
-      (fn []
-        (: vim.opt.listchars :append {:lead :a :trail :b :extends :c})
-        (let [vals (get-o-lo-go :listchars)]
-          (reset-context)
-          (set! :listchars+ {:lead :a :trail :b :extends :c})
-          (assert.is_same vals (get-o-lo-go :listchars)))))
+      (: vim.opt.listchars :append {:lead :a :trail :b :extends :c})
+      (let [vals (get-o-lo-go :listchars)]
+        (reset-context)
+        (set! :listchars+ {:lead :a :trail :b :extends :c})
+        (assert.is_same vals (get-o-lo-go :listchars))))
     (it "can prepend option value of kv-table"
-      (fn []
-        (: vim.opt.listchars :prepend {:lead :a :trail :b :extends :c})
-        (let [vals (get-o-lo-go :listchars)]
-          (reset-context)
-          (set! :listchars^ {:lead :a :trail :b :extends :c})
-          (assert.is_same vals (get-o-lo-go :listchars)))))
+      (: vim.opt.listchars :prepend {:lead :a :trail :b :extends :c})
+      (let [vals (get-o-lo-go :listchars)]
+        (reset-context)
+        (set! :listchars^ {:lead :a :trail :b :extends :c})
+        (assert.is_same vals (get-o-lo-go :listchars))))
     (it "can remove option value of kv-table"
-      (fn []
-        (: vim.opt.listchars :remove [:eol :tab])
-        (let [vals (get-o-lo-go :listchars)]
-          (reset-context)
-          (set! :listchars- [:eol :tab])
-          (assert.is_same vals (get-o-lo-go :listchars)))))
+      (: vim.opt.listchars :remove [:eol :tab])
+      (let [vals (get-o-lo-go :listchars)]
+        (reset-context)
+        (set! :listchars- [:eol :tab])
+        (assert.is_same vals (get-o-lo-go :listchars))))
     (describe "with no value"
       (it "updates option value to `true`"
-        (fn []
-          (vim.cmd "set nowrap")
-          (assert.is_false (get-o :wrap))
-          (set! :wrap)
-          (assert.is_true (get-o :wrap))))
+        (vim.cmd "set nowrap")
+        (assert.is_false (get-o :wrap))
+        (set! :wrap)
+        (assert.is_true (get-o :wrap)))
       (it "updates value to `true` even when option name is hidden in compile time"
-        (fn []
-          (vim.cmd "set nowrap")
-          (assert.is_false (get-o :wrap))
-          (let [name :wrap]
-            (set! name)
-            (assert.is_true (get-o name)))))))
+        (vim.cmd "set nowrap")
+        (assert.is_false (get-o :wrap))
+        (let [name :wrap]
+          (set! name)
+          (assert.is_true (get-o name))))))
   (describe :setlocal!
     (it "can update option value with boolean"
-      (fn []
-        (vim.cmd "setlocal nowrap")
-        (let [vals (get-o-lo-go :wrap)]
-          (reset-context)
-          (setlocal! :wrap false)
-          (assert.is_same vals (get-o-lo-go :wrap)))))
+      (vim.cmd "setlocal nowrap")
+      (let [vals (get-o-lo-go :wrap)]
+        (reset-context)
+        (setlocal! :wrap false)
+        (assert.is_same vals (get-o-lo-go :wrap))))
     (it "can update option value with number"
-      (fn []
-        (vim.cmd "setlocal foldlevel=2")
-        (let [vals (get-o-lo-go :foldlevel)]
-          (reset-context)
-          (setlocal! :foldlevel 2)
-          (assert.is_same vals (get-o-lo-go :foldlevel)))))
+      (vim.cmd "setlocal foldlevel=2")
+      (let [vals (get-o-lo-go :foldlevel)]
+        (reset-context)
+        (setlocal! :foldlevel 2)
+        (assert.is_same vals (get-o-lo-go :foldlevel))))
     (it "can update option value with string"
-      (fn []
-        (vim.cmd "setlocal signcolumn=no")
-        (let [vals (get-o-lo-go :signcolumn)]
-          (reset-context)
-          (setlocal! :signcolumn :no)
-          (assert.is_same vals (get-o-lo-go :signcolumn)))))
+      (vim.cmd "setlocal signcolumn=no")
+      (let [vals (get-o-lo-go :signcolumn)]
+        (reset-context)
+        (setlocal! :signcolumn :no)
+        (assert.is_same vals (get-o-lo-go :signcolumn))))
     (it "can update option value with sequence"
-      (fn []
-        (vim.cmd "setlocal path=/foo,/bar,/baz")
-        (let [vals (get-o-lo-go :path)]
-          (reset-context)
-          (setlocal! :path [:/foo :/bar :/baz])
-          (assert.is_same vals (get-o-lo-go :path)))))
+      (vim.cmd "setlocal path=/foo,/bar,/baz")
+      (let [vals (get-o-lo-go :path)]
+        (reset-context)
+        (setlocal! :path [:/foo :/bar :/baz])
+        (assert.is_same vals (get-o-lo-go :path))))
     (it "can update option value with kv-table"
-      (fn []
-        (vim.cmd "setlocal listchars=eol:a,tab:abc,space:a")
-        (let [vals (get-o-lo-go :listchars)]
-          (reset-context)
-          (setlocal! :listchars {:eol :a :tab :abc :space :a})
-          (assert.is_same vals (get-o-lo-go :listchars)))))
+      (vim.cmd "setlocal listchars=eol:a,tab:abc,space:a")
+      (let [vals (get-o-lo-go :listchars)]
+        (reset-context)
+        (setlocal! :listchars {:eol :a :tab :abc :space :a})
+        (assert.is_same vals (get-o-lo-go :listchars))))
     (it "can update some option value with nil"
-      (fn []
-        (set vim.opt_local.foldlevel nil)
+      (set vim.opt_local.foldlevel nil)
+      (let [vals (get-o-lo-go :foldlevel)]
+        (reset-context)
+        (setlocal! :foldlevel nil)
+        (assert.is_same vals (get-o-lo-go :foldlevel))))
+    (it "can update some option value with symbol"
+      (let [new-val 2]
+        (set vim.opt_local.foldlevel new-val)
         (let [vals (get-o-lo-go :foldlevel)]
           (reset-context)
-          (setlocal! :foldlevel nil)
+          (setlocal! :foldlevel new-val)
           (assert.is_same vals (get-o-lo-go :foldlevel)))))
-    (it "can update some option value with symbol"
-      (fn []
-        (let [new-val 2]
-          (set vim.opt_local.foldlevel new-val)
-          (let [vals (get-o-lo-go :foldlevel)]
-            (reset-context)
-            (setlocal! :foldlevel new-val)
-            (assert.is_same vals (get-o-lo-go :foldlevel))))))
     (it "can update some option value with list"
-      (fn []
-        (let [return-val #2]
-          (set vim.opt_local.foldlevel (return-val))
-          (let [vals (get-o-lo-go :foldlevel)]
-            (reset-context)
-            (setlocal! :foldlevel (return-val))
-            (assert.is_same vals (get-o-lo-go :foldlevel))))))
+      (let [return-val #2]
+        (set vim.opt_local.foldlevel (return-val))
+        (let [vals (get-o-lo-go :foldlevel)]
+          (reset-context)
+          (setlocal! :foldlevel (return-val))
+          (assert.is_same vals (get-o-lo-go :foldlevel)))))
     (it "can append option value of sequence"
-      (fn []
-        (: vim.opt_local.path :append [:/foo :/bar :/baz])
-        (let [vals (get-o-lo-go :path)]
-          (reset-context)
-          (setlocal! :path+ [:/foo :/bar :/baz])
-          (assert.is_same vals (get-o-lo-go :path)))))
+      (: vim.opt_local.path :append [:/foo :/bar :/baz])
+      (let [vals (get-o-lo-go :path)]
+        (reset-context)
+        (setlocal! :path+ [:/foo :/bar :/baz])
+        (assert.is_same vals (get-o-lo-go :path))))
     (it "can prepend option value of sequence"
-      (fn []
-        (: vim.opt_local.path :prepend [:/foo :/bar :/baz])
-        (let [vals (get-o-lo-go :path)]
-          (reset-context)
-          (setlocal! :path^ [:/foo :/bar :/baz])
-          (assert.is_same vals (get-o-lo-go :path)))))
+      (: vim.opt_local.path :prepend [:/foo :/bar :/baz])
+      (let [vals (get-o-lo-go :path)]
+        (reset-context)
+        (setlocal! :path^ [:/foo :/bar :/baz])
+        (assert.is_same vals (get-o-lo-go :path))))
     (it "can remove option value of sequence"
-      (fn []
-        (: vim.opt_local.path :remove [:/tmp :/var])
-        (let [vals (get-o-lo-go :path)]
-          (reset-context)
-          (setlocal! :path- [:/tmp :/var])
-          (assert.is_same vals (get-o-lo-go :path)))))
+      (: vim.opt_local.path :remove [:/tmp :/var])
+      (let [vals (get-o-lo-go :path)]
+        (reset-context)
+        (setlocal! :path- [:/tmp :/var])
+        (assert.is_same vals (get-o-lo-go :path))))
     (it "can append option value of kv-table"
-      (fn []
-        (: vim.opt_local.listchars :append {:lead :a :trail :b :extends :c})
-        (let [vals (get-o-lo-go :listchars)]
-          (reset-context)
-          (setlocal! :listchars+ {:lead :a :trail :b :extends :c})
-          (assert.is_same vals (get-o-lo-go :listchars)))))
+      (: vim.opt_local.listchars :append {:lead :a :trail :b :extends :c})
+      (let [vals (get-o-lo-go :listchars)]
+        (reset-context)
+        (setlocal! :listchars+ {:lead :a :trail :b :extends :c})
+        (assert.is_same vals (get-o-lo-go :listchars))))
     (it "can prepend option value of kv-table"
-      (fn []
-        (: vim.opt_local.listchars :prepend {:lead :a :trail :b :extends :c})
-        (let [vals (get-o-lo-go :listchars)]
-          (reset-context)
-          (setlocal! :listchars^ {:lead :a :trail :b :extends :c})
-          (assert.is_same vals (get-o-lo-go :listchars)))))
+      (: vim.opt_local.listchars :prepend {:lead :a :trail :b :extends :c})
+      (let [vals (get-o-lo-go :listchars)]
+        (reset-context)
+        (setlocal! :listchars^ {:lead :a :trail :b :extends :c})
+        (assert.is_same vals (get-o-lo-go :listchars))))
     (it "can remove option value of kv-table"
-      (fn []
-        (: vim.opt_local.listchars :remove [:eol :tab])
-        (let [vals (get-o-lo-go :listchars)]
-          (reset-context)
-          (setlocal! :listchars- [:eol :tab])
-          (assert.is_same vals (get-o-lo-go :listchars)))))
+      (: vim.opt_local.listchars :remove [:eol :tab])
+      (let [vals (get-o-lo-go :listchars)]
+        (reset-context)
+        (setlocal! :listchars- [:eol :tab])
+        (assert.is_same vals (get-o-lo-go :listchars))))
     (describe "with no value"
       (it "updates option value to `true`"
-        (fn []
-          (vim.cmd "setlocal nowrap")
-          (assert.is_false (get-lo :wrap))
-          (setlocal! :wrap)
-          (assert.is_true (get-lo :wrap))))
+        (vim.cmd "setlocal nowrap")
+        (assert.is_false (get-lo :wrap))
+        (setlocal! :wrap)
+        (assert.is_true (get-lo :wrap)))
       (it "updates value to `true` even when option name is hidden in compile time"
-        (fn []
-          (vim.cmd "setlocal nowrap")
-          (assert.is_false (get-lo :wrap))
-          (let [name :wrap]
-            (setlocal! name)
-            (assert.is_true (get-lo name))))))
+        (vim.cmd "setlocal nowrap")
+        (assert.is_false (get-lo :wrap))
+        (let [name :wrap]
+          (setlocal! name)
+          (assert.is_true (get-lo name)))))
     (describe "for &l:formatoptions"
       (it "can append flags in sequence"
         ;; Note: In truth, the formatoptions flag order doesn't matter.
-        (fn []
-          (setlocal! :formatOptions+ [:a :r :B])
-          (assert.is_same {:1 true :2 true :b true :a true :r true :B true}
-                          (get-lo :formatoptions))))
+        (setlocal! :formatOptions+ [:a :r :B])
+        (assert.is_same {:1 true :2 true :b true :a true :r true :B true}
+                        (get-lo :formatoptions)))
       (it "can prepend flags in sequence"
         ;; Note: In truth, the formatoptions flag order doesn't matter.
-        (fn []
-          (setlocal! :formatOptions^ [:a :r :B])
-          (assert.is_same {:1 true :2 true :b true :a true :r true :B true}
-                          (get-lo :formatoptions))))
+        (setlocal! :formatOptions^ [:a :r :B])
+        (assert.is_same {:1 true :2 true :b true :a true :r true :B true}
+                        (get-lo :formatoptions)))
       (it "can remove flags in sequence"
-        (fn []
-          (setlocal! :formatOptions- [:b :2])
-          (assert.is_same {:1 true} (get-lo :formatoptions))))))
+        (setlocal! :formatOptions- [:b :2])
+        (assert.is_same {:1 true} (get-lo :formatoptions)))))
   (describe :setglobal!
     (it "can update option value with boolean"
-      (fn []
-        (vim.cmd "setglobal nowrap")
-        (let [vals (get-o-lo-go :wrap)]
-          (reset-context)
-          (setglobal! :wrap false)
-          (assert.is_same vals (get-o-lo-go :wrap)))))
+      (vim.cmd "setglobal nowrap")
+      (let [vals (get-o-lo-go :wrap)]
+        (reset-context)
+        (setglobal! :wrap false)
+        (assert.is_same vals (get-o-lo-go :wrap))))
     (it "can update option value with number"
-      (fn []
-        (vim.cmd "setglobal foldlevel=2")
-        (let [vals (get-o-lo-go :foldlevel)]
-          (reset-context)
-          (setglobal! :foldlevel 2)
-          (assert.is_same vals (get-o-lo-go :foldlevel)))))
+      (vim.cmd "setglobal foldlevel=2")
+      (let [vals (get-o-lo-go :foldlevel)]
+        (reset-context)
+        (setglobal! :foldlevel 2)
+        (assert.is_same vals (get-o-lo-go :foldlevel))))
     (it "can update option value with string"
-      (fn []
-        (vim.cmd "setglobal signcolumn=no")
-        (let [vals (get-o-lo-go :signcolumn)]
-          (reset-context)
-          (setglobal! :signcolumn :no)
-          (assert.is_same vals (get-o-lo-go :signcolumn)))))
+      (vim.cmd "setglobal signcolumn=no")
+      (let [vals (get-o-lo-go :signcolumn)]
+        (reset-context)
+        (setglobal! :signcolumn :no)
+        (assert.is_same vals (get-o-lo-go :signcolumn))))
     (it "can update option value with sequence"
-      (fn []
-        (vim.cmd "setglobal path=/foo,/bar,/baz")
-        (let [vals (get-o-lo-go :path)]
-          (reset-context)
-          (setglobal! :path [:/foo :/bar :/baz])
-          (assert.is_same vals (get-o-lo-go :path)))))
+      (vim.cmd "setglobal path=/foo,/bar,/baz")
+      (let [vals (get-o-lo-go :path)]
+        (reset-context)
+        (setglobal! :path [:/foo :/bar :/baz])
+        (assert.is_same vals (get-o-lo-go :path))))
     (it "can update option value with kv-table"
-      (fn []
-        (vim.cmd "setglobal listchars=eol:a,tab:abc,space:a")
-        (let [vals (get-o-lo-go :listchars)]
-          (reset-context)
-          (setglobal! :listchars {:eol :a :tab :abc :space :a})
-          (assert.is_same vals (get-o-lo-go :listchars)))))
+      (vim.cmd "setglobal listchars=eol:a,tab:abc,space:a")
+      (let [vals (get-o-lo-go :listchars)]
+        (reset-context)
+        (setglobal! :listchars {:eol :a :tab :abc :space :a})
+        (assert.is_same vals (get-o-lo-go :listchars))))
     (it "can update some option value with nil"
-      (fn []
-        (set vim.opt_global.foldlevel nil)
+      (set vim.opt_global.foldlevel nil)
+      (let [vals (get-o-lo-go :foldlevel)]
+        (reset-context)
+        (setglobal! :foldlevel nil)
+        (assert.is_same vals (get-o-lo-go :foldlevel))))
+    (it "can update some option value with symbol"
+      (let [new-val 2]
+        (set vim.opt_global.foldlevel new-val)
         (let [vals (get-o-lo-go :foldlevel)]
           (reset-context)
-          (setglobal! :foldlevel nil)
+          (setglobal! :foldlevel new-val)
           (assert.is_same vals (get-o-lo-go :foldlevel)))))
-    (it "can update some option value with symbol"
-      (fn []
-        (let [new-val 2]
-          (set vim.opt_global.foldlevel new-val)
-          (let [vals (get-o-lo-go :foldlevel)]
-            (reset-context)
-            (setglobal! :foldlevel new-val)
-            (assert.is_same vals (get-o-lo-go :foldlevel))))))
     (it "can update some option value with list"
-      (fn []
-        (let [return-val #2]
-          (set vim.opt_global.foldlevel (return-val))
-          (let [vals (get-o-lo-go :foldlevel)]
-            (reset-context)
-            (setglobal! :foldlevel (return-val))
-            (assert.is_same vals (get-o-lo-go :foldlevel))))))
+      (let [return-val #2]
+        (set vim.opt_global.foldlevel (return-val))
+        (let [vals (get-o-lo-go :foldlevel)]
+          (reset-context)
+          (setglobal! :foldlevel (return-val))
+          (assert.is_same vals (get-o-lo-go :foldlevel)))))
     (it "can append option value of sequence"
-      (fn []
-        (: vim.opt_global.path :append [:/foo :/bar :/baz])
-        (let [vals (get-o-lo-go :path)]
-          (reset-context)
-          (setglobal! :path+ [:/foo :/bar :/baz])
-          (assert.is_same vals (get-o-lo-go :path)))))
+      (: vim.opt_global.path :append [:/foo :/bar :/baz])
+      (let [vals (get-o-lo-go :path)]
+        (reset-context)
+        (setglobal! :path+ [:/foo :/bar :/baz])
+        (assert.is_same vals (get-o-lo-go :path))))
     (it "can prepend option value of sequence"
-      (fn []
-        (: vim.opt_global.path :prepend [:/foo :/bar :/baz])
-        (let [vals (get-o-lo-go :path)]
-          (reset-context)
-          (setglobal! :path^ [:/foo :/bar :/baz])
-          (assert.is_same vals (get-o-lo-go :path)))))
+      (: vim.opt_global.path :prepend [:/foo :/bar :/baz])
+      (let [vals (get-o-lo-go :path)]
+        (reset-context)
+        (setglobal! :path^ [:/foo :/bar :/baz])
+        (assert.is_same vals (get-o-lo-go :path))))
     (it "can remove option value of sequence"
-      (fn []
-        (: vim.opt_global.path :remove [:/tmp :/var])
-        (let [vals (get-o-lo-go :path)]
-          (reset-context)
-          (setglobal! :path- [:/tmp :/var])
-          (assert.is_same vals (get-o-lo-go :path)))))
+      (: vim.opt_global.path :remove [:/tmp :/var])
+      (let [vals (get-o-lo-go :path)]
+        (reset-context)
+        (setglobal! :path- [:/tmp :/var])
+        (assert.is_same vals (get-o-lo-go :path))))
     (it "can append option value of kv-table"
-      (fn []
-        (: vim.opt_global.listchars :append {:lead :a :trail :b :extends :c})
-        (let [vals (get-o-lo-go :listchars)]
-          (reset-context)
-          (setglobal! :listchars+ {:lead :a :trail :b :extends :c})
-          (assert.is_same vals (get-o-lo-go :listchars)))))
+      (: vim.opt_global.listchars :append {:lead :a :trail :b :extends :c})
+      (let [vals (get-o-lo-go :listchars)]
+        (reset-context)
+        (setglobal! :listchars+ {:lead :a :trail :b :extends :c})
+        (assert.is_same vals (get-o-lo-go :listchars))))
     (it "can prepend option value of kv-table"
-      (fn []
-        (: vim.opt_global.listchars :prepend {:lead :a :trail :b :extends :c})
-        (let [vals (get-o-lo-go :listchars)]
-          (reset-context)
-          (setglobal! :listchars^ {:lead :a :trail :b :extends :c})
-          (assert.is_same vals (get-o-lo-go :listchars)))))
+      (: vim.opt_global.listchars :prepend {:lead :a :trail :b :extends :c})
+      (let [vals (get-o-lo-go :listchars)]
+        (reset-context)
+        (setglobal! :listchars^ {:lead :a :trail :b :extends :c})
+        (assert.is_same vals (get-o-lo-go :listchars))))
     (it "can remove option value of kv-table"
-      (fn []
-        (: vim.opt_global.listchars :remove [:eol :tab])
-        (let [vals (get-o-lo-go :listchars)]
-          (reset-context)
-          (setglobal! :listchars- [:eol :tab])
-          (assert.is_same vals (get-o-lo-go :listchars)))))
+      (: vim.opt_global.listchars :remove [:eol :tab])
+      (let [vals (get-o-lo-go :listchars)]
+        (reset-context)
+        (setglobal! :listchars- [:eol :tab])
+        (assert.is_same vals (get-o-lo-go :listchars))))
     (describe "for &l:shortmess"
       (it "can append flags in sequence"
         ;; Note: In truth, the shortmess flag order doesn't matter.
-        (fn []
-          (setglobal! :shortMess+ [:m :n :r])
-          (assert.is_same {:f true :i true :w true :m true :n true :r true}
-                          (get-lo :shortmess))))
+        (setglobal! :shortMess+ [:m :n :r])
+        (assert.is_same {:f true :i true :w true :m true :n true :r true}
+                        (get-lo :shortmess)))
       (it "can prepend flags in sequence"
         ;; Note: In truth, the shortmess flag order doesn't matter.
-        (fn []
-          (setglobal! :shortMess^ [:m :n :r])
-          (assert.is_same {:f true :i true :w true :m true :n true :r true}
-                          (get-lo :shortmess))))
+        (setglobal! :shortMess^ [:m :n :r])
+        (assert.is_same {:f true :i true :w true :m true :n true :r true}
+                        (get-lo :shortmess)))
       (it "can remove flags in sequence"
-        (fn []
-          (setglobal! :shortMess- [:i :f])
-          (assert.is_same {:w true} (get-lo :shortmess)))))
+        (setglobal! :shortMess- [:i :f])
+        (assert.is_same {:w true} (get-lo :shortmess))))
     (describe "with no value"
       (it "updates option value to `true`"
-        (fn []
-          (vim.cmd "setglobal nowrap")
-          (assert.is_false (get-go :wrap))
-          (setglobal! :wrap)
-          (assert.is_true (get-go :wrap))))
+        (vim.cmd "setglobal nowrap")
+        (assert.is_false (get-go :wrap))
+        (setglobal! :wrap)
+        (assert.is_true (get-go :wrap)))
       (it "updates value to `true` even when option name is hidden in compile time"
-        (fn []
-          (vim.cmd "setglobal nowrap")
-          (assert.is_false (get-go :wrap))
-          (let [name :wrap]
-            (setglobal! name)
-            (assert.is_true (get-go name)))))))
+        (vim.cmd "setglobal nowrap")
+        (assert.is_false (get-go :wrap))
+        (let [name :wrap]
+          (setglobal! name)
+          (assert.is_true (get-go name))))))
   (describe :bo!
     (it "can update option value with boolean"
-      (fn []
-        (tset vim.bo :expandtab false)
-        (let [vals (get-o-lo-go :expandtab)]
-          (reset-context)
-          (bo! :expandtab false)
-          (assert.is_same vals (get-o-lo-go :expandtab)))))
+      (tset vim.bo :expandtab false)
+      (let [vals (get-o-lo-go :expandtab)]
+        (reset-context)
+        (bo! :expandtab false)
+        (assert.is_same vals (get-o-lo-go :expandtab))))
     (it "can update option value with number"
-      (fn []
-        (tset vim.bo :tabstop 2)
-        (let [vals (get-o-lo-go :tabstop)]
-          (reset-context)
-          (bo! :tabstop 2)
-          (assert.is_same vals (get-o-lo-go :tabstop)))))
+      (tset vim.bo :tabstop 2)
+      (let [vals (get-o-lo-go :tabstop)]
+        (reset-context)
+        (bo! :tabstop 2)
+        (assert.is_same vals (get-o-lo-go :tabstop))))
     (it "can update option value with string"
-      (fn []
-        (tset vim.bo :omnifunc :abc)
-        (let [vals (get-o-lo-go :omnifunc)]
-          (reset-context)
-          (bo! :omnifunc :abc)
-          (assert.is_same vals (get-o-lo-go :omnifunc)))))
+      (tset vim.bo :omnifunc :abc)
+      (let [vals (get-o-lo-go :omnifunc)]
+        (reset-context)
+        (bo! :omnifunc :abc)
+        (assert.is_same vals (get-o-lo-go :omnifunc))))
     (it "can update option value with sequence"
-      (fn []
-        (tset vim.bo :path "/foo,/bar,/baz")
-        (let [vals (get-o-lo-go :path)]
-          (reset-context)
-          (bo! :path [:/foo :/bar :/baz])
-          (assert.is_same vals (get-o-lo-go :path)))))
+      (tset vim.bo :path "/foo,/bar,/baz")
+      (let [vals (get-o-lo-go :path)]
+        (reset-context)
+        (bo! :path [:/foo :/bar :/baz])
+        (assert.is_same vals (get-o-lo-go :path))))
     (it "can update option value with kv-table"
-      (fn []
-        (tset vim.bo :matchpairs "a:A,b:B,c:C")
-        (let [vals (get-o-lo-go :matchpairs)]
-          (reset-context)
-          (bo! :matchPairs {:a :A :b :B :c :C})
-          (assert.is_same vals (get-o-lo-go :matchpairs)))))
+      (tset vim.bo :matchpairs "a:A,b:B,c:C")
+      (let [vals (get-o-lo-go :matchpairs)]
+        (reset-context)
+        (bo! :matchPairs {:a :A :b :B :c :C})
+        (assert.is_same vals (get-o-lo-go :matchpairs))))
     (it "can update some option value with nil"
-      (fn []
-        (set vim.bo.tabstop nil)
+      (set vim.bo.tabstop nil)
+      (let [vals (get-o-lo-go :tabstop)]
+        (reset-context)
+        (bo! :tabstop nil)
+        (assert.is_same vals (get-o-lo-go :tabstop))))
+    (it "can update some option value with symbol"
+      (let [new-val 2]
+        (set vim.bo.tabstop new-val)
         (let [vals (get-o-lo-go :tabstop)]
           (reset-context)
-          (bo! :tabstop nil)
+          (bo! :tabstop new-val)
           (assert.is_same vals (get-o-lo-go :tabstop)))))
-    (it "can update some option value with symbol"
-      (fn []
-        (let [new-val 2]
-          (set vim.bo.tabstop new-val)
-          (let [vals (get-o-lo-go :tabstop)]
-            (reset-context)
-            (bo! :tabstop new-val)
-            (assert.is_same vals (get-o-lo-go :tabstop))))))
     (it "can update some option value with list"
-      (fn []
-        (let [return-val #2]
-          (set vim.bo.tabstop (return-val))
-          (let [vals (get-o-lo-go :tabstop)]
-            (reset-context)
-            (bo! :tabstop (return-val))
-            (assert.is_same vals (get-o-lo-go :tabstop))))))
+      (let [return-val #2]
+        (set vim.bo.tabstop (return-val))
+        (let [vals (get-o-lo-go :tabstop)]
+          (reset-context)
+          (bo! :tabstop (return-val))
+          (assert.is_same vals (get-o-lo-go :tabstop)))))
     (describe "with bufnr"
       (it "can update option value with boolean"
-        (fn []
-          (let [buf (vim.api.nvim_get_current_buf)]
-            (reset-context)
-            (bo! buf :expandtab false)
-            (assert.is_false (. vim.bo buf :expandtab)))))
+        (let [buf (vim.api.nvim_get_current_buf)]
+          (reset-context)
+          (bo! buf :expandtab false)
+          (assert.is_false (. vim.bo buf :expandtab))))
       (it "can update option value with number"
-        (fn []
-          (let [buf (vim.api.nvim_get_current_buf)]
-            (reset-context)
-            (bo! buf :tabstop 2)
-            (assert.is_same 2 (. vim.bo buf :tabstop)))))
+        (let [buf (vim.api.nvim_get_current_buf)]
+          (reset-context)
+          (bo! buf :tabstop 2)
+          (assert.is_same 2 (. vim.bo buf :tabstop))))
       (it "can update option value with string"
-        (fn []
-          (let [buf (vim.api.nvim_get_current_buf)]
-            (reset-context)
-            (bo! buf :omnifunc :abc)
-            (assert.is_same :abc (. vim.bo buf :omnifunc)))))
+        (let [buf (vim.api.nvim_get_current_buf)]
+          (reset-context)
+          (bo! buf :omnifunc :abc)
+          (assert.is_same :abc (. vim.bo buf :omnifunc))))
       (it "can update option value with sequence"
-        (fn []
-          (let [buf (vim.api.nvim_get_current_buf)]
-            (reset-context)
-            (bo! buf :path [:/foo :/bar :/baz])
-            (assert.is_same "/foo,/bar,/baz" (. vim.bo buf :path)))))
+        (let [buf (vim.api.nvim_get_current_buf)]
+          (reset-context)
+          (bo! buf :path [:/foo :/bar :/baz])
+          (assert.is_same "/foo,/bar,/baz" (. vim.bo buf :path))))
       (it "can update option value with kv-table"
-        (fn []
-          (let [buf (vim.api.nvim_get_current_buf)]
-            (reset-context)
-            (bo! buf :matchPairs {:a :A :b :B :c :C})
-            (assert.is_same "a:A,b:B,c:C" (. vim.bo buf :matchpairs)))))
+        (let [buf (vim.api.nvim_get_current_buf)]
+          (reset-context)
+          (bo! buf :matchPairs {:a :A :b :B :c :C})
+          (assert.is_same "a:A,b:B,c:C" (. vim.bo buf :matchpairs))))
       (it "can update some option value with nil"
-        (fn []
-          (let [buf (vim.api.nvim_get_current_buf)]
-            (reset-context)
-            (bo! buf :tabstop nil)
-            (assert.is_same vim.go.tabstop (. vim.bo buf :tabstop)))))
+        (let [buf (vim.api.nvim_get_current_buf)]
+          (reset-context)
+          (bo! buf :tabstop nil)
+          (assert.is_same vim.go.tabstop (. vim.bo buf :tabstop))))
       (it "can update some option value with symbol"
-        (fn []
-          (let [buf (vim.api.nvim_get_current_buf)
-                new-val 2]
-            (reset-context)
-            (bo! buf :tabstop new-val)
-            (assert.is_same new-val (. vim.bo buf :tabstop)))))
+        (let [buf (vim.api.nvim_get_current_buf)
+              new-val 2]
+          (reset-context)
+          (bo! buf :tabstop new-val)
+          (assert.is_same new-val (. vim.bo buf :tabstop))))
       (it "can update some option value with list"
-        (fn []
-          (let [buf (vim.api.nvim_get_current_buf)
-                new-val 2
-                return-val #new-val]
-            (reset-context)
-            (bo! buf :tabstop (return-val))
-            (assert.is_same new-val (. vim.bo buf :tabstop)))))))
+        (let [buf (vim.api.nvim_get_current_buf)
+              new-val 2
+              return-val #new-val]
+          (reset-context)
+          (bo! buf :tabstop (return-val))
+          (assert.is_same new-val (. vim.bo buf :tabstop))))))
   (describe :wo!
     (it "can update option value with boolean"
-      (fn []
-        (tset vim.wo :wrap false)
-        (let [vals (get-o-lo-go :wrap)]
-          (reset-context)
-          (wo! :wrap false)
-          (assert.is_same vals (get-o-lo-go :wrap)))))
+      (tset vim.wo :wrap false)
+      (let [vals (get-o-lo-go :wrap)]
+        (reset-context)
+        (wo! :wrap false)
+        (assert.is_same vals (get-o-lo-go :wrap))))
     (it "can update option value with number"
-      (fn []
-        (tset vim.wo :foldlevel 2)
-        (let [vals (get-o-lo-go :foldlevel)]
-          (reset-context)
-          (wo! :foldlevel 2)
-          (assert.is_same vals (get-o-lo-go :foldlevel)))))
+      (tset vim.wo :foldlevel 2)
+      (let [vals (get-o-lo-go :foldlevel)]
+        (reset-context)
+        (wo! :foldlevel 2)
+        (assert.is_same vals (get-o-lo-go :foldlevel))))
     (it "can update option value with string"
-      (fn []
-        (tset vim.wo :signcolumn :no)
-        (let [vals (get-o-lo-go :signcolumn)]
-          (reset-context)
-          (wo! :signcolumn :no)
-          (assert.is_same vals (get-o-lo-go :signcolumn)))))
+      (tset vim.wo :signcolumn :no)
+      (let [vals (get-o-lo-go :signcolumn)]
+        (reset-context)
+        (wo! :signcolumn :no)
+        (assert.is_same vals (get-o-lo-go :signcolumn))))
     (it "can update option value with sequence"
-      (fn []
-        (tset vim.wo :colorcolumn "80,81,82")
-        (let [vals (get-o-lo-go :colorcolumn)]
-          (reset-context)
-          (wo! :colorcolumn [:80 :81 :82])
-          (assert.is_same vals (get-o-lo-go :colorcolumn)))))
+      (tset vim.wo :colorcolumn "80,81,82")
+      (let [vals (get-o-lo-go :colorcolumn)]
+        (reset-context)
+        (wo! :colorcolumn [:80 :81 :82])
+        (assert.is_same vals (get-o-lo-go :colorcolumn))))
     (it "can update option value with kv-table"
-      (fn []
-        (tset vim.wo :listchars "eol:a,tab:abc,space:a")
-        (let [vals (get-o-lo-go :listchars)]
-          (reset-context)
-          (wo! :listchars {:eol :a :tab :abc :space :a})
-          (assert.is_same vals (get-o-lo-go :listchars)))))
+      (tset vim.wo :listchars "eol:a,tab:abc,space:a")
+      (let [vals (get-o-lo-go :listchars)]
+        (reset-context)
+        (wo! :listchars {:eol :a :tab :abc :space :a})
+        (assert.is_same vals (get-o-lo-go :listchars))))
     (it "can update some option value with nil"
-      (fn []
-        (set vim.wo.foldlevel nil)
+      (set vim.wo.foldlevel nil)
+      (let [vals (get-o-lo-go :foldlevel)]
+        (reset-context)
+        (wo! :foldlevel nil)
+        (assert.is_same vals (get-o-lo-go :foldlevel))))
+    (it "can update some option value with symbol"
+      (let [new-val 2]
+        (set vim.wo.foldlevel new-val)
         (let [vals (get-o-lo-go :foldlevel)]
           (reset-context)
-          (wo! :foldlevel nil)
+          (wo! :foldlevel new-val)
           (assert.is_same vals (get-o-lo-go :foldlevel)))))
-    (it "can update some option value with symbol"
-      (fn []
-        (let [new-val 2]
-          (set vim.wo.foldlevel new-val)
-          (let [vals (get-o-lo-go :foldlevel)]
-            (reset-context)
-            (wo! :foldlevel new-val)
-            (assert.is_same vals (get-o-lo-go :foldlevel))))))
     (it "can update some option value with list"
-      (fn []
-        (let [return-val #2]
-          (set vim.wo.foldlevel (return-val))
-          (let [vals (get-o-lo-go :foldlevel)]
-            (reset-context)
-            (wo! :foldlevel (return-val))
-            (assert.is_same vals (get-o-lo-go :foldlevel))))))
+      (let [return-val #2]
+        (set vim.wo.foldlevel (return-val))
+        (let [vals (get-o-lo-go :foldlevel)]
+          (reset-context)
+          (wo! :foldlevel (return-val))
+          (assert.is_same vals (get-o-lo-go :foldlevel)))))
     (describe "with win-id"
       (it "can update option value with woolean"
-        (fn []
-          (let [win (vim.api.nvim_get_current_win)]
-            (vim.cmd.new)
-            (wo! win :wrap false)
-            (assert.is_false (. vim.wo win :wrap)))))
+        (let [win (vim.api.nvim_get_current_win)]
+          (vim.cmd.new)
+          (wo! win :wrap false)
+          (assert.is_false (. vim.wo win :wrap))))
       (it "can update option value with number"
-        (fn []
-          (let [win (vim.api.nvim_get_current_win)]
-            (vim.cmd.new)
-            (wo! win :foldlevel 2)
-            (assert.is_same 2 (. vim.wo win :foldlevel)))))
+        (let [win (vim.api.nvim_get_current_win)]
+          (vim.cmd.new)
+          (wo! win :foldlevel 2)
+          (assert.is_same 2 (. vim.wo win :foldlevel))))
       (it "can update option value with string"
-        (fn []
-          (let [win (vim.api.nvim_get_current_win)]
-            (vim.cmd.new)
-            (wo! win :signcolumn :no)
-            (assert.is_same :no (. vim.wo win :signcolumn)))))
+        (let [win (vim.api.nvim_get_current_win)]
+          (vim.cmd.new)
+          (wo! win :signcolumn :no)
+          (assert.is_same :no (. vim.wo win :signcolumn))))
       (it "can update option value with sequence"
-        (fn []
-          (let [win (vim.api.nvim_get_current_win)]
-            (vim.cmd.new)
-            (wo! win :colorcolumn [:80 :81 :82])
-            (assert.is_same "80,81,82" (. vim.wo win :colorcolumn)))))
+        (let [win (vim.api.nvim_get_current_win)]
+          (vim.cmd.new)
+          (wo! win :colorcolumn [:80 :81 :82])
+          (assert.is_same "80,81,82" (. vim.wo win :colorcolumn))))
       (it "can update option value with kv-table"
-        (fn []
-          (let [win (vim.api.nvim_get_current_win)]
-            (vim.cmd.new)
-            (wo! win :listchars {:eol :a :tab :abc :space :a})
-            (assert.is_same "eol:a,tab:abc,space:a" (. vim.wo win :listchars)))))
+        (let [win (vim.api.nvim_get_current_win)]
+          (vim.cmd.new)
+          (wo! win :listchars {:eol :a :tab :abc :space :a})
+          (assert.is_same "eol:a,tab:abc,space:a" (. vim.wo win :listchars))))
       (it "can update some option value with nil"
-        (fn []
-          (let [win (vim.api.nvim_get_current_win)]
-            (vim.cmd.new)
-            (wo! win :foldlevel nil)
-            (assert.is_same vim.go.foldlevel (. vim.wo win :foldlevel)))))
+        (let [win (vim.api.nvim_get_current_win)]
+          (vim.cmd.new)
+          (wo! win :foldlevel nil)
+          (assert.is_same vim.go.foldlevel (. vim.wo win :foldlevel))))
       (it "can update some option value with symbol"
-        (fn []
-          (let [win (vim.api.nvim_get_current_win)
-                new-val 2]
-            (vim.cmd.new)
-            (wo! win :foldlevel new-val)
-            (assert.is_same new-val (. vim.wo win :foldlevel)))))
+        (let [win (vim.api.nvim_get_current_win)
+              new-val 2]
+          (vim.cmd.new)
+          (wo! win :foldlevel new-val)
+          (assert.is_same new-val (. vim.wo win :foldlevel))))
       (it "can update some option value with list"
-        (fn []
-          (let [win (vim.api.nvim_get_current_win)
-                new-val 2
-                return-val #new-val]
-            (vim.cmd.new)
-            (wo! win :foldlevel (return-val))
-            (assert.is_same new-val (. vim.wo win :foldlevel)))))))
+        (let [win (vim.api.nvim_get_current_win)
+              new-val 2
+              return-val #new-val]
+          (vim.cmd.new)
+          (wo! win :foldlevel (return-val))
+          (assert.is_same new-val (. vim.wo win :foldlevel))))))
   (describe :set+
     (it "appends option value of sequence"
-      #(let [name :path
-             assigned-val [:/foo :/bar :/baz]]
-         (-> (. vim.opt name) (: :append assigned-val))
-         (let [expected-vals (get-o-lo-go name)]
-           (reset-context)
-           (set+ name assigned-val)
-           (assert.is_same expected-vals (get-o-lo-go name)))))
+      (let [name :path
+            assigned-val [:/foo :/bar :/baz]]
+        (-> (. vim.opt name) (: :append assigned-val))
+        (let [expected-vals (get-o-lo-go name)]
+          (reset-context)
+          (set+ name assigned-val)
+          (assert.is_same expected-vals (get-o-lo-go name)))))
     (it "appends option value of kv-table"
-      #(let [name :listchars
-             assigned-val {:lead :a :trail :b :extends :c}]
-         (-> (. vim.opt name) (: :append assigned-val))
-         (let [expected-vals (get-o-lo-go name)]
-           (reset-context)
-           (set+ name assigned-val)
-           (assert.is_same expected-vals (get-o-lo-go name))))))
+      (let [name :listchars
+            assigned-val {:lead :a :trail :b :extends :c}]
+        (-> (. vim.opt name) (: :append assigned-val))
+        (let [expected-vals (get-o-lo-go name)]
+          (reset-context)
+          (set+ name assigned-val)
+          (assert.is_same expected-vals (get-o-lo-go name))))))
   (describe :set^
     (it "prepends option value of sequence"
-      #(let [name :path
-             assigned-val [:/foo :/bar :/baz]]
-         (-> (. vim.opt name) (: :prepend assigned-val))
-         (let [expected-vals (get-o-lo-go name)]
-           (reset-context)
-           (set^ name assigned-val)
-           (assert.is_same expected-vals (get-o-lo-go name)))))
+      (let [name :path
+            assigned-val [:/foo :/bar :/baz]]
+        (-> (. vim.opt name) (: :prepend assigned-val))
+        (let [expected-vals (get-o-lo-go name)]
+          (reset-context)
+          (set^ name assigned-val)
+          (assert.is_same expected-vals (get-o-lo-go name)))))
     (it "prepends option value of kv-table"
-      #(let [name :listchars
-             assigned-val {:lead :a :trail :b :extends :c}]
-         (-> (. vim.opt name) (: :prepend assigned-val))
-         (let [expected-vals (get-o-lo-go name)]
-           (reset-context)
-           (set^ name assigned-val)
-           (assert.is_same expected-vals (get-o-lo-go name))))))
+      (let [name :listchars
+            assigned-val {:lead :a :trail :b :extends :c}]
+        (-> (. vim.opt name) (: :prepend assigned-val))
+        (let [expected-vals (get-o-lo-go name)]
+          (reset-context)
+          (set^ name assigned-val)
+          (assert.is_same expected-vals (get-o-lo-go name))))))
   (describe :set-
     (it "removes option value of sequence"
-      #(let [name :path
-             assigned-val [:/tmp :/var]]
-         (-> (. vim.opt name) (: :remove assigned-val))
-         (let [expected-vals (get-o-lo-go name)]
-           (reset-context)
-           (set- name assigned-val)
-           (assert.is_same expected-vals (get-o-lo-go name)))))
+      (let [name :path
+            assigned-val [:/tmp :/var]]
+        (-> (. vim.opt name) (: :remove assigned-val))
+        (let [expected-vals (get-o-lo-go name)]
+          (reset-context)
+          (set- name assigned-val)
+          (assert.is_same expected-vals (get-o-lo-go name)))))
     (it "removes option value of kv-table"
-      #(let [name :listchars
-             assigned-val {:lead :a :trail :b :extends :c}]
-         (-> (. vim.opt name) (: :remove assigned-val))
-         (let [expected-vals (get-o-lo-go name)]
-           (reset-context)
-           (set- name assigned-val)
-           (assert.is_same expected-vals (get-o-lo-go name)))))))
+      (let [name :listchars
+            assigned-val {:lead :a :trail :b :extends :c}]
+        (-> (. vim.opt name) (: :remove assigned-val))
+        (let [expected-vals (get-o-lo-go name)]
+          (reset-context)
+          (set- name assigned-val)
+          (assert.is_same expected-vals (get-o-lo-go name)))))))

--- a/tests/spec/prerequisites_spec.fnl
+++ b/tests/spec/prerequisites_spec.fnl
@@ -1,6 +1,6 @@
+(import-macros {: describe : it} :_busted_macros)
+
 (describe :prerequisites
-          (fn []
-            (it "vim.api is not nil"
-                (fn []
-                  (assert.is_not_nil vim)
-                  (assert.is_not_nil vim.api)))))
+  (it "vim.api is not nil"
+    (assert.is_not_nil vim)
+    (assert.is_not_nil vim.api)))

--- a/tests/spec/variable_spec.fnl
+++ b/tests/spec/variable_spec.fnl
@@ -1,24 +1,25 @@
 (import-macros {: b! : env!} :nvim-laurel.macros)
 
 (describe :b!
-  (before_each (fn []
-                 (set vim.b.foo nil)
-                 (set vim.b.bar nil)
-                 (set vim.env.FOO nil)
-                 (set vim.env.BAR nil)))
-  (it "sets environment variable in the editor session"
-    #(do
-       (env! :FOO :foo)
-       (env! :$BAR :bar)
-       (assert.is.same :foo vim.env.FOO)
-       (assert.is.same :bar vim.env.BAR)))
-  (it "sets buffer-local variable"
-    #(let [buf (vim.api.nvim_get_current_buf)]
-       (vim.cmd.new)
-       (vim.cmd.only)
-       (b! :foo :foo1)
-       (b! buf :bar :bar1)
-       (assert.is_nil (. vim.b buf :foo))
-       (assert.is_nil vim.b.bar)
-       (assert.is.same :foo1 vim.b.foo)
-       (assert.is.same :bar1 (. vim.b buf :bar)))))
+  (fn []
+    (before_each (fn []
+                   (set vim.b.foo nil)
+                   (set vim.b.bar nil)
+                   (set vim.env.FOO nil)
+                   (set vim.env.BAR nil)))
+    (it "sets environment variable in the editor session"
+      #(do
+         (env! :FOO :foo)
+         (env! :$BAR :bar)
+         (assert.is.same :foo vim.env.FOO)
+         (assert.is.same :bar vim.env.BAR)))
+    (it "sets buffer-local variable"
+      #(let [buf (vim.api.nvim_get_current_buf)]
+         (vim.cmd.new)
+         (vim.cmd.only)
+         (b! :foo :foo1)
+         (b! buf :bar :bar1)
+         (assert.is_nil (. vim.b buf :foo))
+         (assert.is_nil vim.b.bar)
+         (assert.is.same :foo1 vim.b.foo)
+         (assert.is.same :bar1 (. vim.b buf :bar))))))

--- a/tests/spec/variable_spec.fnl
+++ b/tests/spec/variable_spec.fnl
@@ -1,25 +1,25 @@
+(import-macros {: describe : it} :_busted_macros)
 (import-macros {: b! : env!} :nvim-laurel.macros)
 
 (describe :b!
-  (fn []
-    (before_each (fn []
-                   (set vim.b.foo nil)
-                   (set vim.b.bar nil)
-                   (set vim.env.FOO nil)
-                   (set vim.env.BAR nil)))
-    (it "sets environment variable in the editor session"
-      #(do
-         (env! :FOO :foo)
-         (env! :$BAR :bar)
-         (assert.is.same :foo vim.env.FOO)
-         (assert.is.same :bar vim.env.BAR)))
-    (it "sets buffer-local variable"
-      #(let [buf (vim.api.nvim_get_current_buf)]
-         (vim.cmd.new)
-         (vim.cmd.only)
-         (b! :foo :foo1)
-         (b! buf :bar :bar1)
-         (assert.is_nil (. vim.b buf :foo))
-         (assert.is_nil vim.b.bar)
-         (assert.is.same :foo1 vim.b.foo)
-         (assert.is.same :bar1 (. vim.b buf :bar))))))
+  (before_each (fn []
+                 (set vim.b.foo nil)
+                 (set vim.b.bar nil)
+                 (set vim.env.FOO nil)
+                 (set vim.env.BAR nil)))
+  (it "sets environment variable in the editor session"
+    (do
+      (env! :FOO :foo)
+      (env! :$BAR :bar)
+      (assert.is.same :foo vim.env.FOO)
+      (assert.is.same :bar vim.env.BAR)))
+  (it "sets buffer-local variable"
+    (let [buf (vim.api.nvim_get_current_buf)]
+      (vim.cmd.new)
+      (vim.cmd.only)
+      (b! :foo :foo1)
+      (b! buf :bar :bar1)
+      (assert.is_nil (. vim.b buf :foo))
+      (assert.is_nil vim.b.bar)
+      (assert.is.same :foo1 vim.b.foo)
+      (assert.is.same :bar1 (. vim.b buf :bar)))))

--- a/tests/spec/variable_spec.fnl
+++ b/tests/spec/variable_spec.fnl
@@ -8,11 +8,10 @@
                  (set vim.env.FOO nil)
                  (set vim.env.BAR nil)))
   (it "sets environment variable in the editor session"
-    (do
-      (env! :FOO :foo)
-      (env! :$BAR :bar)
-      (assert.is.same :foo vim.env.FOO)
-      (assert.is.same :bar vim.env.BAR)))
+    (env! :FOO :foo)
+    (env! :$BAR :bar)
+    (assert.is.same :foo vim.env.FOO)
+    (assert.is.same :bar vim.env.BAR))
   (it "sets buffer-local variable"
     (let [buf (vim.api.nvim_get_current_buf)]
       (vim.cmd.new)


### PR DESCRIPTION
Replace just two (`it` and `describe`) with macro ones.

Do not the others:
- The others are rarely used.
- Whether they are used depends on files.
- Revising tests could add extra works to add or remove symbols in `import-macros`.
