### PR TITLE
refactor(utils): avoid regex metachars in `g:laurel_deprecated`

### DIFF
--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -274,7 +274,7 @@
                                     ,(printf "%s. `:cexpr g:laurel_deprecated` would help you update it. See `:h g:laurel_deprecated` for the details."
                                              version)
                                     :nvim-laurel false)
-        msg (printf "[nvim-laurel] %s is deprecated. Please update it with %s."
+        msg (printf "nvim-laurel: %s is deprecated. Please update it with %s."
                     deprecated alternative)
         {: filename : line} deprecate/ast
         ?msg-in-gcc-error-format (when filename


### PR DESCRIPTION
For `:Cfilter` on quickfix.