### PR TITLE
feat: add option `&default-opts`

### DIFF
--- a/doc/laurel.md
+++ b/doc/laurel.md
@@ -867,10 +867,11 @@ determined at runtime.
 ```fennel
 ;; bad
 (autocmd! group [:FileType]
-  #(let [buf-au! (fn [...]
+  (fn []
+    (let [buf-au! (fn [...]
                    (autocmd! &default-opts {:buffer 0} ...))]
-     (buf-au! [:InsertEnter] (do :something))
-     (buf-au! [:BufWritePre] (do :other))))
+      (buf-au! [:InsertEnter] #(do :something))
+      (buf-au! [:BufWritePre] #(do :other))))
 ```
 
 ##### Pattern
@@ -883,9 +884,9 @@ determined at runtime.
   `(autocmd! &default-opts {:buffer 0} ,...))
 
 (autocmd! group [:FileType]
-  #(do
-     (buf-au! [:InsertEnter] (do :something))
-     (buf-au! [:BufWritePre] (do :other))))
+  (fn []
+     (buf-au! [:InsertEnter] #(do :something))
+     (buf-au! [:BufWritePre] #(do :other))))
 ```
 
 or

--- a/doc/laurel.md
+++ b/doc/laurel.md
@@ -142,6 +142,7 @@ Create or get an augroup, or override an existing augroup.
   Note: Set `vim.fn.foobar` to call Vim script function `foobar` without table
   argument from `nvim_create_autocmd()`; on the other hand, set
   `#(vim.fn.foobar $)` to call `foobar` with the table argument.
+
 - [`?api-opts`](#api-opts): (kv-table) `:h nvim_create_autocmd()`.
 
 ```fennel
@@ -260,6 +261,7 @@ Map `lhs` to `rhs` in `modes`, non-recursively by default.
   - Set it in bare-string.
   - Insert `&vim` symbol just before the callback.
   - Name the first symbol for the callback to match `^<.+>` in Lua pattern.
+
 - [`?api-opts`](#api-opts): (kv-table) `:h nvim_set_keymap()`.
 
 ```fennel
@@ -929,6 +931,7 @@ runtime.
 1. Update deprecated features
 
    This is a list of useful commands:
+
    - With [`:cdo`] or [`:cfdo`],
      - [`:norm`][`:normal`] or [`:normal`]
      - [`:g`][`:global`] or [`:global`]

--- a/doc/laurel.md
+++ b/doc/laurel.md
@@ -87,6 +87,8 @@ the following features:
 
 ### &default-opts
 
+(Since v0.6.1)
+
 A symbol to set default values of `api-opts` field. It indicates that the bare
 kv-table next to `&default-opts` contains default values for `api-opts`, but
 it also accepts the additional keys available in `extra-opts`. To set boolean

--- a/doc/laurel.md
+++ b/doc/laurel.md
@@ -89,9 +89,44 @@ the following features:
 
 A symbol to set default values of `api-opts` field. It indicates that the bare
 kv-table next to `&default-opts` contains default values for `api-opts`, but
-it also accept the same keys as `extra-opts`. To set boolean option, it
-requires to set to either `true` or `false` in spite of the syntax of
-`extra-opts` itself.
+it also accepts the additional keys available in `extra-opts`. To set boolean
+option, it requires to set to either `true` or `false` in spite of the syntax
+of `extra-opts` itself.
+
+Note that quote parts depend on where the wrapper macros are defined:
+
+- To define a wrapper **macro** to be expanded in the **same** file, quote the
+  entire `list` of the imported macro (and unquote as you need). For example,
+
+  ```fennel
+  ;; in foobar.fnl
+  (import-macros {: map!} :nvim-laurel)
+
+  (macro buf-map! [...]
+    `(map! &default-opts {:buffer 0} ,...))
+
+  (buf-map! :lhs :rhs)
+  ```
+
+- To define a wrapper **function** to be imported as a macro in **another**
+  file, just quote `&default-opts`. For example,
+
+  ```fennel
+  ;; in my/macros.fnl
+  (local {: map!} (require :nvim-laurel))
+
+  (fn buf-map! [...]
+    (map! `&default-opts {:buffer 0} ...))
+
+  {: buf-map!}
+  ```
+
+  ```fennel
+  ;; in foobar.fnl (another file)
+  (import-macros {: buf-map!} :my.macros)
+
+  (buf-map! :lhs :rhs)
+  ```
 
 ## Macros
 

--- a/doc/laurel.md
+++ b/doc/laurel.md
@@ -863,6 +863,7 @@ determined at runtime.
 ##### Anti-Pattern
 
 ```fennel
+;; bad
 (autocmd! group [:FileType]
   #(let [buf-au! (fn [...]
                    (autocmd! &default-opts {:buffer 0} ...))]
@@ -873,6 +874,7 @@ determined at runtime.
 ##### Pattern
 
 ```fennel
+;; good
 (import-macros {: autocmd!} :nvim-laurel)
 
 (macro buf-au! [...]
@@ -887,6 +889,7 @@ determined at runtime.
 or
 
 ```fennel
+;; good
 ;; in my/macros.fnl
 (local {: atocmd!} (require :nvim-laurel))
 
@@ -922,6 +925,7 @@ It could be an unexpected behavior that `autocmd` whose callback ends with
 ##### Anti-Pattern
 
 ```fennel
+;; bad
 (autocmd! group events #(pcall foobar))
 (autocmd! group events (fn []
                          ;; Do something else
@@ -931,6 +935,7 @@ It could be an unexpected behavior that `autocmd` whose callback ends with
 ##### Pattern
 
 ```fennel
+;; good
 (macro ->nil [...]
   "Make sure to return `nil`."
   `(do
@@ -954,6 +959,7 @@ in another anonymous function is meaningless in many cases.
 ##### Anti-Pattern
 
 ```fennel
+;; bad
 (autocmd! group events #(vim.schedule #(nnoremap [:buffer $.buf] :lhs :rhs)))
 (autocmd! group events (fn []
                          (vim.schedule #(nnoremap [:buffer $.buf] :lhs :rhs))))
@@ -962,6 +968,7 @@ in another anonymous function is meaningless in many cases.
 ##### Pattern
 
 ```fennel
+;; good
 (autocmd! group events #(vim.schedule (fn []
                                         (nnoremap [:buffer $.buf] :lhs :rhs))))
 ```

--- a/doc/laurel.md
+++ b/doc/laurel.md
@@ -91,7 +91,7 @@ A symbol to set default values of `api-opts` field. It indicates that the bare
 kv-table next to `&default-opts` contains default values for `api-opts`, but
 it also accepts the additional keys available in `extra-opts`. To set boolean
 option, it requires to set to either `true` or `false` in spite of the syntax
-of `extra-opts` itself. See also its [Anti-Patterns][WIP].
+of `extra-opts` itself. See also its [Anti-Patterns](#default-opts-1).
 
 Note that quote parts depend on where the wrapper macros are defined:
 
@@ -859,8 +859,6 @@ To create wrapper of nvim-laurel macro, it is unrecommended to wrap them in
 runtime function; instead, wrap them in macro.
 Fennel macros cannot parse the contents of `varargs` (`...`) which is only
 determined at runtime.
-
-See also [`&default-opts`][default-opts].
 
 ##### Anti-Pattern
 

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -1015,8 +1015,10 @@
                          (values extra-opts a2 ?a3 ?a4)
                          (values extra-opts a1 ?a3 ?a4)))
         ?bufnr (if extra-opts.<buffer> 0 extra-opts.buffer)
-        api-opts (merge-api-opts (command/->compatible-opts! extra-opts)
-                                 ?api-opts)]
+        api-opts (-> extra-opts
+                     (default/merge-opts!)
+                     (command/->compatible-opts!)
+                     (merge-api-opts ?api-opts))]
     (if ?bufnr
         `(vim.api.nvim_buf_create_user_command ,?bufnr ,name ,command ,api-opts)
         `(vim.api.nvim_create_user_command ,name ,command ,api-opts))))

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -1014,9 +1014,9 @@
           extra-opts (if (sequence? a1)
                          (values extra-opts a2 ?a3 ?a4)
                          (values extra-opts a1 ?a3 ?a4)))
-        ?bufnr (if extra-opts.<buffer> 0 extra-opts.buffer)
-        api-opts (-> (default/merge-opts! extra-opts)
-                     (command/->compatible-opts!)
+        extra-opts* (default/merge-opts! extra-opts)
+        ?bufnr (if extra-opts*.<buffer> 0 extra-opts*.buffer)
+        api-opts (-> (command/->compatible-opts! extra-opts*)
                      (merge-api-opts ?api-opts))]
     (if ?bufnr
         `(vim.api.nvim_buf_create_user_command ,?bufnr ,name ,command ,api-opts)

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -1005,14 +1005,14 @@
     The same as {opts} for `nvim_create_user_command`."
   (let [?seq-extra-opts (if (sequence? a1) a1
                             (sequence? a2) a2)
-        [extra-opts name command ?api-opts] ;
+        (extra-opts name command ?api-opts) ;
         (case (when ?seq-extra-opts
                 (seq->kv-table ?seq-extra-opts
                                [:bar :bang :<buffer> :register :keepscript]))
-          nil [{} a1 a2 ?a3]
+          nil (values {} a1 a2 ?a3)
           extra-opts (if (sequence? a1)
-                         [extra-opts a2 ?a3 ?a4]
-                         [extra-opts a1 ?a3 ?a4]))
+                         (values extra-opts a2 ?a3 ?a4)
+                         (values extra-opts a1 ?a3 ?a4)))
         ?bufnr (if extra-opts.<buffer> 0 extra-opts.buffer)
         api-opts (merge-api-opts (command/->compatible-opts! extra-opts)
                                  ?api-opts)]

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -583,7 +583,7 @@
   (set opts.literal nil)
   opts)
 
-(lambda keymap/parse-args [args]
+(lambda keymap/parse-args [...]
   "Parse map! macro args in sequence.
   ```fennel
   (keymap/parse-args ?extra-opts lhs rhs ?api-opts)
@@ -597,7 +597,8 @@
   @return lhs string
   @return rhs string|function
   @return ?api-opts kv-table"
-  (let [([modes a1 a2 ?a3 ?a4] {:&vim ?vim-indice}) ;
+  (let [args (default/extract-opts! [...])
+        ([modes a1 a2 ?a3 ?a4] {:&vim ?vim-indice}) ;
         (extract-symbols args [`&vim])]
     (if (kv-table? a1) (values a1 a2 ?a3 ?a4)
         (let [?seq-extra-opts (if (sequence? a1) a1
@@ -610,15 +611,16 @@
                                                    (sequence? a1)
                                                    [?extra-opts a2 ?a3 ?a4]
                                                    [?extra-opts a1 ?a3 ?a4])
+              extra-opts* (default/merge-opts! extra-opts)
               rhs (if (or ?vim-indice (str? raw-rhs)
                           (vim-callback-format? raw-rhs))
                       raw-rhs
                       (do
-                        (set extra-opts.callback raw-rhs)
+                        (set extra-opts*.callback raw-rhs)
                         ""))
-              ?bufnr (if extra-opts.<buffer> 0 extra-opts.buffer)]
-          (set extra-opts.buffer ?bufnr)
-          (values modes extra-opts lhs rhs ?api-opts)))))
+              ?bufnr (if extra-opts*.<buffer> 0 extra-opts*.buffer)]
+          (set extra-opts*.buffer ?bufnr)
+          (values modes extra-opts* lhs rhs ?api-opts)))))
 
 (lambda keymap/del-maps! [...]
   "Delete keymap.
@@ -697,11 +699,8 @@
   @param rhs string|function
   @param ?api-opts kv-table"
   (let [default-opts {:noremap true}
-        args (default/extract-opts! [...])
-        (modes extra-opts lhs rhs ?api-opts) (keymap/parse-args args)
-        extra-opts* (tbl/merge default-opts ;
-                               (default/release-opts!) ;
-                               extra-opts)]
+        (modes extra-opts lhs rhs ?api-opts) (keymap/parse-args ...)
+        extra-opts* (tbl/merge default-opts extra-opts)]
     (keymap/set-maps! modes extra-opts* lhs rhs ?api-opts)))
 
 (lambda unmap! [...]

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -1015,8 +1015,7 @@
                          (values extra-opts a2 ?a3 ?a4)
                          (values extra-opts a1 ?a3 ?a4)))
         ?bufnr (if extra-opts.<buffer> 0 extra-opts.buffer)
-        api-opts (-> extra-opts
-                     (default/merge-opts!)
+        api-opts (-> (default/merge-opts! extra-opts)
                      (command/->compatible-opts!)
                      (merge-api-opts ?api-opts))]
     (if ?bufnr

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -988,7 +988,7 @@
   (set opts.<buffer> nil)
   opts)
 
-(lambda command! [a1 a2 ?a3 ?a4]
+(lambda command! [...]
   "Define a user command.
   ```fennel
   (command! ?extra-opts name command ?api-opts)
@@ -1003,7 +1003,8 @@
   @param command string|function Replacement command.
   @param ?api-opts kv-table Optional command attributes.
     The same as {opts} for `nvim_create_user_command`."
-  (let [?seq-extra-opts (if (sequence? a1) a1
+  (let [[a1 a2 ?a3 ?a4] (default/extract-opts! [...])
+        ?seq-extra-opts (if (sequence? a1) a1
                             (sequence? a2) a2)
         (extra-opts name command ?api-opts) ;
         (case (when ?seq-extra-opts

--- a/tests/spec/_wrapper_macros.fnl
+++ b/tests/spec/_wrapper_macros.fnl
@@ -21,8 +21,7 @@
       ...)))
 
 (fn buf-autocmd!/with-no-default-bufnr [buffer ...]
-  (augroup! :buf-local-augroup
-    (autocmd! `&default-opts {: buffer} ...)))
+  (autocmd! `&default-opts {: buffer} ...))
 
 (fn buf-autocmd!/with-buffer=0 [...]
   (autocmd! `&default-opts {:buffer 0} ...))

--- a/tests/spec/_wrapper_macros.fnl
+++ b/tests/spec/_wrapper_macros.fnl
@@ -1,5 +1,5 @@
 ;; fennel-ls: macro-file
-(local {: augroup! : autocmd! : set! : map! : highlight!}
+(local {: augroup! : autocmd! : set! : map! : command! : highlight!}
        (require :nvim-laurel.macros))
 
 (fn augroup+ [...]
@@ -35,6 +35,9 @@
 (fn buf-map!/with-buffer=0 [...]
   (map! `&default-opts {:buffer 0} ...))
 
+(fn buf-command!/as-api-alias [bufnr ...]
+  (command! `&default-opts {:buffer bufnr} ...))
+
 (fn bold-highlight! [...]
   (highlight! `&default-opts {:bold true} ...))
 
@@ -54,5 +57,6 @@
  : omni-map!
  : remap!
  : buf-map!/with-buffer=0
+ : buf-command!/as-api-alias
  : bold-highlight!
  : hi!-link-by-default}

--- a/tests/spec/_wrapper_macros.fnl
+++ b/tests/spec/_wrapper_macros.fnl
@@ -7,6 +7,11 @@
     {:clear false}
     ...))
 
+(fn buf-augroup! [name ...]
+  "Create an buffer-local augroup. Only expected to be defined in ***hashfn***
+  in an autocmd."
+  (augroup! (: "%s-%d" :format name `$.buf) ...))
+
 (fn buf-autocmd!/with-no-default-bufnr [buffer ...]
   (augroup! :buf-local-augroup
     (autocmd! `&default-opts {: buffer} ...)))
@@ -51,6 +56,7 @@
     _ (highlight! ...)))
 
 {: augroup+
+ : buf-augroup!
  : buf-autocmd!/with-no-default-bufnr
  : buf-autocmd!/with-buffer=0
  : set+

--- a/tests/spec/_wrapper_macros.fnl
+++ b/tests/spec/_wrapper_macros.fnl
@@ -14,9 +14,11 @@
     ...))
 
 (fn buf-augroup! [name ...]
-  "Create an buffer-local augroup. Only expected to be defined in ***hashfn***
-  in an autocmd."
-  (augroup! (: "%s-%d" :format name `$.buf) ...))
+  "Create an buffer-local augroup. This macro is supposed to be expanded in
+  another parent augroup or in ftplugin."
+  (let [augroup-name `(: "%s%d" :format ,name (vim.api.nvim_get_current_buf))]
+    (augroup! augroup-name
+      ...)))
 
 (fn buf-autocmd!/with-no-default-bufnr [buffer ...]
   (augroup! :buf-local-augroup

--- a/tests/spec/_wrapper_macros.fnl
+++ b/tests/spec/_wrapper_macros.fnl
@@ -35,6 +35,9 @@
 (fn buf-map!/with-buffer=0 [...]
   (map! `&default-opts {:buffer 0} ...))
 
+(fn buf-map!/with-<buffer>=true [...]
+  (map! `&default-opts {:<buffer> true} ...))
+
 (fn buf-command!/as-api-alias [bufnr ...]
   (command! `&default-opts {:buffer bufnr} ...))
 
@@ -57,6 +60,7 @@
  : omni-map!
  : remap!
  : buf-map!/with-buffer=0
+ : buf-map!/with-<buffer>=true
  : buf-command!/as-api-alias
  : bold-highlight!
  : hi!-link-by-default}

--- a/tests/spec/_wrapper_macros.fnl
+++ b/tests/spec/_wrapper_macros.fnl
@@ -2,6 +2,12 @@
 (local {: augroup! : autocmd! : set! : map! : command! : highlight!}
        (require :nvim-laurel.macros))
 
+(fn my-autocmd! [...]
+  "Create an autocmd in predefined augroup, but the augroup MUST be defined
+  outside of macro definition file. It requires the carefully conflicted
+  variable assigned an augroup in global-scope."
+  (autocmd! `_G.my-augroup-id ...))
+
 (fn augroup+ [...]
   (augroup! `&default-opts
     {:clear false}
@@ -55,7 +61,8 @@
     1 (highlight! `&default-opts {:link ref} ...)
     _ (highlight! ...)))
 
-{: augroup+
+{: my-autocmd!
+ : augroup+
  : buf-augroup!
  : buf-autocmd!/with-no-default-bufnr
  : buf-autocmd!/with-buffer=0

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -51,15 +51,16 @@
 ;; nvim nightly v0.10; use `vim.api.nvim_exec_autocmds` instead.
 (describe :autocmd
   (setup (fn []
+           (let [nvim-builtin-augroups [:nvim_cmdwin :nvim_terminal]]
+             (each [_ group (ipairs nvim-builtin-augroups)]
+               (augroup! group)))
            (vim.cmd "function g:Test() abort\nendfunction")))
   (teardown (fn []
               (vim.cmd "delfunction g:Test")))
   (before_each (fn []
                  (augroup! default-augroup)
-                 (let [aus (get-autocmds)]
-                   ;; TODO: Automate to clear any autocmds.
-                   ;; (let [aus (get-autocmds {:group false})])
-                   (assert.is.same {} aus))))
+                 (let [aus (get-autocmds {})]
+                   (assert.is_nil (next aus)))))
   (after_each (fn []
                 (pcall del-autocmd au-id1)
                 (pcall del-autocmd au-id2)

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -245,7 +245,7 @@
                 `(autocmd! id &default-opts {:buffer undefined-var.buf} ,...))
               (assert.is_false foo)
               (assert.has_no_error #(autocmd! id [:FileType] [:foobar]
-                                              (fn [a]
+                                              (fn [_a]
                                                 (buf-au! [:InsertEnter]
                                                          #(set foo true)))))
               (assert.has_error #(set vim.bo.filetype :foobar))))))

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -230,12 +230,10 @@
                 (assert.is_false foo)
                 (vim.api.nvim_exec_autocmds :InsertEnter {:buffer bufnr})
                 (assert.is_true foo)
-                (let [[au1 au2 &as aus] (get-autocmds {:group id})]
-                  (pending #(assert.is_same 2 (length aus)))
-                  (pending #(assert.is_same :FileType au1.event))
-                  (pending #(assert.is_same :InsertEnter au2.event))
-                  (pending #(assert.is_nil au1.buffer))
-                  (pending #(assert.is_same bufnr au2.buffer))))))
+                (let [[au1 &as aus] (get-autocmds {:group id :buffer bufnr})]
+                  (assert.is_same 1 (length aus))
+                  (assert.is_same :InsertEnter au1.event)
+                  (assert.is_same bufnr au1.buffer)))))
           (it "can spawn a buffer-local augroup"
             (let [group-name "spawn buffer-local augroup"
                   local-group-prefix :local]
@@ -267,16 +265,17 @@
               (assert.is_same 1 (length aus))
               (assert.is_same :FileType au.event))
             (set vim.bo.filetype :foo)
-            (let [bufnr (vim.api.nvim_get_current_buf)
-                  macro-gen-group-name (.. local-group-prefix bufnr)]
+            (let [buffer (vim.api.nvim_get_current_buf)
+                  macro-gen-group-name (.. local-group-prefix buffer)]
               (let [[au &as aus] (get-autocmds {:group macro-gen-group-name})]
                 (assert.is_same 1 (length aus))
-                (assert.is_same :InsertEnter au.event))))))
-      (vim.api.nvim_exec_autocmds :InsertEnter {:buffer bufnr})
-      (let [[au1 au2 &as aus] (get-autocmds {:group macro-gen-group-name})]
-        (pending #(assert.is_same 2 (length aus)))
-        (pending #(assert.is_same {:InsertEnter true :BufWritePre true}
-                                  {au1.event true au2.event true})))
+                (assert.is_same :InsertEnter au.event))
+              (vim.api.nvim_exec_autocmds :InsertEnter {: buffer})
+              (let [[au1 au2 &as aus] (get-autocmds {:group macro-gen-group-name
+                                                     : buffer})]
+                (assert.is_same 2 (length aus))
+                (assert.is_same {:InsertEnter true :BufWritePre true}
+                                {au1.event true au2.event true}))))))
       (describe "wrapper function at runtime"
         (it "usually causes errors because compiled into unexpected output."
           (autocmd! default-augroup [:FileType]

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -90,13 +90,13 @@
                            (autocmd! a.group [:BufWritePre] [:buffer 0]
                                      default-callback)))))
           (assert-spy s :was_not_called)
-          (let [aus (vim.api.nvim_get_autocmds {:event :InsertEnter})]
+          (let [aus (get-autocmds {:event :InsertEnter})]
             (assert.is_same 1 (length aus)))
           (vim.api.nvim_exec_autocmds :InsertEnter {:buffer 0})
           (assert-spy s :was_called)
-          (let [aus (vim.api.nvim_get_autocmds {:event :InsertEnter})]
+          (let [aus (get-autocmds {:event :InsertEnter})]
             (assert.is_same 1 (length aus)))
-          (let [aus (vim.api.nvim_get_autocmds {:event [:BufWritePre]})]
+          (let [aus (get-autocmds {:event [:BufWritePre]})]
             (assert.is_same 1 (length aus)))))
       (it "callback arg value at `group` is same as the parent group id."
         (let [s (spy.new)]
@@ -128,7 +128,7 @@
           (assert-spy s :was_not_called)
           (exec-autocmds :InsertEnter {:group default-augroup})
           (assert-spy s :was_called)
-          (pending #(let [[au1 au2 &as aus] (vim.api.nvim_get_autocmds {:group default-augroup})]
+          (pending #(let [[au1 au2 &as aus] (get-autocmds {:group default-augroup})]
                       (assert.is_same {:InsertEnter true :BufWritePre true}
                                       {au1.event true au2.event true})
                       (assert.is_same 2 (length aus)))))))

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -258,7 +258,7 @@
             (augroup! group-name
               (au! [:FileType]
                    #(buf-augroup! local-group-prefix
-                      (au! [:InsertEnter] [:<buffer> :desc "spawned autocmd"]
+                      (au! [:InsertEnter] [:buffer 0 :desc "spawned autocmd"]
                            (fn [a]
                              (buf-autocmd!/with-buffer=0 a.group [:BufWritePre]
                                                          default-callback
@@ -268,17 +268,15 @@
               (assert.is_same :FileType au.event))
             (set vim.bo.filetype :foo)
             (let [bufnr (vim.api.nvim_get_current_buf)
-                  macro-gen-group-name (.. local-group-prefix bufnr)
-                  [au &as aus] (get-autocmds {:group macro-gen-group-name})]
-              (assert.is_same 1 (length aus))
-              (assert.is_same :InsertEnter au.event))
-            (vim.fn.feedkeys :i :ni)
-            (let [bufnr (vim.api.nvim_get_current_buf)
-                  macro-gen-group-name (.. local-group-prefix bufnr)
-                  [au1 au2 &as aus] (get-autocmds {:group macro-gen-group-name})]
-              (assert.is_same 2 (length aus))
-              (assert.is_same {:InsertEnter true :BufWritePre true}
-                              {au1.event true au2.event true})))))
+                  macro-gen-group-name (.. local-group-prefix bufnr)]
+              (let [[au &as aus] (get-autocmds {:group macro-gen-group-name})]
+                (assert.is_same 1 (length aus))
+                (assert.is_same :InsertEnter au.event))
+              (vim.fn.feedkeys :i :ni)
+              (let [[au1 au2 &as aus] (get-autocmds {:group macro-gen-group-name})]
+                (assert.is_same 2 (length aus))
+                (assert.is_same {:InsertEnter true :BufWritePre true}
+                                {au1.event true au2.event true}))))))
       (describe "wrapper function at runtime"
         (it "usually causes errors because compiled into unexpected output."
           (autocmd! default-augroup [:FileType]

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -7,11 +7,17 @@
 
 (set _G.my-augroup-id (augroup! :MyAugroup))
 
+(macro assert-spy [spy-instance method ...]
+  `((. (assert.spy ,spy-instance) ,method) ,...))
+
 (macro macro-callback []
   `#:macro-callback)
 
 (macro macro-command []
   :macro-command)
+
+(local del-autocmd vim.api.nvim_del_autocmd)
+(local exec-autocmds vim.api.nvim_exec_autocmds)
 
 (local default-augroup :default-test-augroup)
 (local default-event :BufRead)
@@ -37,6 +43,10 @@
 (lambda get-first-autocmd [?opts]
   (. (get-autocmds ?opts) 1))
 
+(var au-id1 nil)
+(var au-id2 nil)
+(var au-id3 nil)
+
 ;; Note: `(vim.cmd "normal! i")` does not trigger event `InsertEnter` in the
 ;; nvim nightly v0.10; use `vim.api.nvim_exec_autocmds` instead.
 (describe :autocmd
@@ -50,6 +60,10 @@
                    ;; TODO: Automate to clear any autocmds.
                    ;; (let [aus (get-autocmds {:group false})])
                    (assert.is.same {} aus))))
+  (after_each (fn []
+                (pcall del-autocmd au-id1)
+                (pcall del-autocmd au-id2)
+                (pcall del-autocmd au-id3)))
   (describe :augroup!
     (it "returns augroup id without autocmds insides"
       (let [id (augroup! default-augroup)]
@@ -63,227 +77,75 @@
                                [default-event default-callback]
                                (au! :FileType [:foo :bar] #:foobar)))))
   (describe :au!/autocmd!
+    (describe "nested autocmds"
+      (it "callback arg value at `group` is `nil` when parent group is `nil`."
+        (let [desc "nil group to InsertEnter"
+              s (spy.new)]
+          (set au-id1
+               (au! nil [:InsertEnter] [:buffer 0 :desc desc]
+                    (fn [a]
+                      (assert.is_nil a.group)
+                      (s)
+                      (set au-id2
+                           (autocmd! a.group [:BufWritePre] [:buffer 0]
+                                     default-callback)))))
+          (assert-spy s :was_not_called)
+          (let [aus (vim.api.nvim_get_autocmds {:event :InsertEnter})]
+            (assert.is_same 1 (length aus)))
+          (vim.api.nvim_exec_autocmds :InsertEnter {:buffer 0})
+          (assert-spy s :was_called)
+          (let [aus (vim.api.nvim_get_autocmds {:event :InsertEnter})]
+            (assert.is_same 1 (length aus)))
+          (let [aus (vim.api.nvim_get_autocmds {:event [:BufWritePre]})]
+            (assert.is_same 1 (length aus)))))
+      (it "callback arg value at `group` is same as the parent group id."
+        (let [local-group "local group"
+              group-id (augroup! local-group)
+              s (spy.new)]
+          (set au-id1
+              (au! local-group [:InsertEnter]
+                    [:buffer 0 :desc "spawned autocmd"]
+                    (fn [a]
+                      (assert.is_same group-id a.group)
+                      (s)
+                      (set au-id2
+                          (autocmd! a.group [:BufWritePre] [:buffer 0]
+                                    default-callback
+                                    {:desc "spawned autocmd, nested"})))))
+          (assert-spy s :was_not_called)
+          (exec-autocmds :InsertEnter {:group local-group})
+          (assert-spy s :was_called)
+          (let [[au1 au2 &as aus] (get-autocmds {:group local-group})]
+            (assert.is_same {:InsertEnter true :BufWritePre true}
+                            {au1.event true au2.event true})
+            (assert.is_same 2 (length aus)))))
+      (it "callback arg value at `group` is same as the parent group id even inside `augroup!` macro."
+        (let [local-group "local group"
+              s (spy.new)]
+          (augroup! local-group
+            (au! [:InsertEnter] [:buffer 0 :desc "spawned autocmd"]
+                 (fn [a]
+                   (s)
+                   (autocmd! a.group [:BufWritePre] [:buffer 0] default-callback
+                             {:desc "spawned autocmd, nested"}))))
+          (assert-spy s :was_not_called)
+          (exec-autocmds :InsertEnter {:group local-group})
+          (assert-spy s :was_called)
+          (let [[au1 au2 &as aus] (vim.api.nvim_get_autocmds {:group local-group})]
+            (assert.is_same {:InsertEnter true :BufWritePre true}
+                            {au1.event true au2.event true})
+            (assert.is_same 2 (length aus))))))
     (it "should set callback via macro"
       (let [desc "macro callback"]
-        (autocmd! default-augroup default-event [:pat] [:desc desc]
-                  (macro-callback))
+        (set au-id1 (autocmd! default-augroup default-event [:pat] [:desc desc]
+                              (macro-callback)))
         (let [au (get-first-autocmd {:pattern :pat})]
           (assert.is_same desc au.desc))))
     (it "should set callback function in symbol"
-      (autocmd! default-augroup default-event [:pat] default-callback)
+      (set au-id1 (autocmd! default-augroup default-event [:pat]
+                            default-callback))
       (assert.is_same default-callback
-                      (. (get-first-autocmd {:pattern :pat}) :callback)))
-    (it "should set callback function in multi-symbol"
-      (let [desc :multi.sym]
-        (autocmd! default-augroup default-event [:pat] default.multi.sym
-                  {: desc})
-        ;; FIXME: In vusted, callback is unexpectedly set to a string
-        ;; "<vim function: default.multi.sym>"; it must be the same as
-        ;; `default.multi.sym`.
-        (assert.is_same desc (. (get-first-autocmd {:pattern :pat}) :desc))))
-    (it "should set callback function in list"
-      (let [desc :list]
-        (autocmd! default-augroup default-event [:pat]
-                  (default-callback :foo :bar) {: desc})
-        (let [au (get-first-autocmd {:pattern :pat})]
-          (assert.is_same desc au.desc))))
-    (it "should set vim.fn.Test in string \"Test\""
-      (autocmd! default-augroup default-event [:pat] vim.fn.Test)
-      (let [au (get-first-autocmd {:pattern :pat})]
-        (assert.is_same "<vim function: Test>" au.callback)))
-    (it "set #(vim.fn.Test) to callback without modification"
-      (autocmd! default-augroup default-event [:pat] #(vim.fn.Test))
-      (let [au (get-first-autocmd {:pattern :pat})]
-        (assert.is_not_same "<vim function: Test>" au.callback)))
-    (it "can add an autocmd to an existing augroup"
-      (autocmd! default-augroup default-event [:pat1 :pat2] default-callback)
-      (let [[autocmd] (get-autocmds)]
-        (assert.is.same default-callback autocmd.callback)))
-    (it "can add autocmd with no patterns for macro"
-      (assert.has_no.errors #(autocmd! default-augroup default-event
-                                       default-callback)))
-    (it "sets vim.fn.Test to callback in string"
-      (assert.has_no.errors #(autocmd! default-augroup default-event
-                                       vim.fn.Test))
-      (let [[autocmd] (get-autocmds)]
-        (assert.is.same "<vim function: Test>" autocmd.callback)))
-    (it "creates buffer-local autocmd with `buffer` key"
-      (let [buffer (vim.api.nvim_get_current_buf)
-            au1 (au! default-augroup default-event [:buffer buffer]
-                     default-callback)]
-        (vim.cmd.new)
-        (vim.cmd.only)
-        (let [au2 (au! default-augroup default-event [:<buffer>]
-                       default-callback)
-              [autocmd1] (get-autocmds {: buffer})
-              [autocmd2] ;
-              (get-autocmds {:buffer (vim.api.nvim_get_current_buf)})]
-          (assert.is.same au1 autocmd1.id)
-          (assert.is.same au2 autocmd2.id))))
-    (it "can define autocmd without any augroup"
-      (assert.has_no.errors #(let [id (au! nil default-event default-callback)]
-                               (vim.api.nvim_del_autocmd id))))
-    (it "gives lowest priority to `pattern` as (< raw seq tbl)"
-      (let [seq-pat :seq-pat
-            tbl-pat :tbl-pat]
-        (au! default-augroup default-event [:raw-seq-pat] default-callback)
-        (au! default-augroup default-event [:pattern seq-pat] default-callback)
-        (au! default-augroup default-event default-callback {:pattern tbl-pat})
-        (let [au (get-first-autocmd {:pattern [:raw-seq-pat]})]
-          (assert.is.same :raw-seq-pat au.pattern))
-        (let [au (get-first-autocmd {:pattern seq-pat})]
-          (assert.is.same seq-pat au.pattern))
-        (let [au (get-first-autocmd {:pattern tbl-pat})]
-          (assert.is.same tbl-pat au.pattern))))
-    (describe "detects 2 args:"
-      (it "sequence pattern and string callback"
-        (autocmd! default-augroup default-event [:pat] :callback))
-      (it "sequence pattern and function callback"
-        (autocmd! default-augroup default-event [:pat] #:callback))
-      (it "sequence pattern and symbol callback"
-        (let [cb :callback]
-          (autocmd! default-augroup default-event [:pat] cb)))
-      (it "extra-opts and string callback"
-        (autocmd! default-augroup default-event [:pat] :callback))
-      (it "extra-opts and function callback"
-        (autocmd! default-augroup default-event [:pat] #:callback))
-      (it "extra-opts and symbol callback"
-        (let [cb :callback]
-          (autocmd! default-augroup default-event [:pat] cb)))
-      (it "string callback and api-opts in table"
-        (autocmd! default-augroup default-event :callback {:nested true}))
-      (it "string callback and api-opts in symbol"
-        (let [opts {:nested true}]
-          (autocmd! default-augroup default-event :callback opts)))
-      (it "function callback and api-opts in table"
-        (autocmd! default-augroup default-event #:callback {:nested true}))
-      (it "function callback and api-opts in symbol"
-        (let [opts {:nested true}]
-          (autocmd! default-augroup default-event #:callback opts)))
-      (it "symbol callback and api-opts in table"
-        (let [cb :callback]
-          (autocmd! default-augroup default-event cb {:nested true})))
-      (it "symbol callback and api-opts in symbol"
-        (let [cb :callback
-              opts {:nested true}]
-          (autocmd! default-augroup default-event cb opts)))))
-  (describe :<Cmd>pattern
-    (it "symbol will be set to 'command'"
-      (au! default-augroup default-event [:pat1] <default>-command)
-      (let [au (get-first-autocmd {:pattern :pat1})]
-        (assert.is.same <default>-command au.command)))
-    (it "list will be set to 'command'"
-      (au! default-augroup default-event [:pat1] (<default>-str-callback))
-      (let [au (get-first-autocmd {:pattern :pat1})]
-        (assert.is.same (<default>-str-callback) au.command))))
-  (describe "with symbol &vim"
-    (it "should set symbol to `command`"
-      (au! default-augroup default-event [:pat1] &vim default-command)
-      (let [[autocmd1] (get-autocmds {:pattern :pat1})]
-        (assert.is.same default-command autocmd1.command)))
-    (it "should set list to `command`"
-      (autocmd! default-augroup default-event [:pat] &vim (macro-command))
-      (let [au (get-first-autocmd {:pattern :pat})]
-        (assert.is_same :macro-command au.command))))
-  (describe "(wrapper)"
-    (describe "with `&default-opts`,"
-      (describe "imported macro"
-        (describe :augroup+
-          (it "gets an existing augroup id"
-            (let [id (augroup! default-augroup)]
-              (assert.is.same id (augroup+ default-augroup))))
-          (it "can add autocmds to an existing augroup within `augroup+`"
-            (augroup+ default-augroup
-              (au! default-event [:pat1 :pat2] default-callback))
-            (let [[autocmd] (get-autocmds)]
-              (assert.is.same default-callback autocmd.callback))))
-        (it "can create autocmd in predefined augroup in global-scope"
-          (assert.has_no_error #(my-autocmd! [:FileType] [:foo]
-                                             default-callback))
-          (let [[au &as aus] (get-autocmds {:group _G.my-augroup-id})]
-            (assert.is_same 1 (length aus))
-            (assert.is_same :foo au.pattern))))
-      (describe "local macro"
-        (describe "carefully binding variables without gensym in order to get conflicted with existing variable"
-          ;; Note: Another spec, carelessly bound to undefined variable,
-          ;; throws error too earlier in nvim >= 0.10.
-          (it "can define buffer-local autocmd wrapper"
-            (var foo false)
-            (let [id (augroup! default-augroup)]
-              (macro buf-au! [...]
-                `(autocmd! id &default-opts {:buffer a.buf} ,...))
-              (assert.is_false foo)
-              (autocmd! id [:FileType] [:foobar]
-                        (fn [a]
-                          (buf-au! [:InsertEnter] #(set foo true))))
-              (assert.is_false foo)
-              (let [buffer (vim.api.nvim_get_current_buf)]
-                (set vim.bo.filetype :foobar)
-                (assert.is_false foo)
-                (vim.api.nvim_exec_autocmds :InsertEnter {: buffer})
-                (assert.is_true foo)
-                (let [[au1 &as aus] (get-autocmds {:group id : buffer})]
-                  (assert.is_same 1 (length aus))
-                  (assert.is_same :InsertEnter au1.event)
-                  (assert.is_same buffer au1.buffer)))))
-          (it "can spawn a buffer-local augroup"
-            (let [group-name "spawn buffer-local augroup"
-                  local-group-prefix :local]
-              (augroup! group-name
-                (au! [:FileType]
-                     #(buf-augroup! local-group-prefix
-                        (au! [:InsertEnter] [:<buffer>] default-callback))))
-              (let [[au &as aus] (get-autocmds {:group group-name})]
-                (assert.is_same 1 (length aus))
-                (assert.is_same :FileType au.event))
-              (set vim.bo.filetype :foo)
-              (let [bufnr (vim.api.nvim_get_current_buf)
-                    macro-gen-group-name (.. local-group-prefix bufnr)
-                    [au1 &as aus] (get-autocmds {:group macro-gen-group-name})]
-                (assert.is_same 1 (length aus))
-                (assert.is_same :InsertEnter au1.event)))))
-        (it "can spawn buffer-local autocmd from a spawned buffer-local augroup"
-          (let [group-name "spawn buffer-local augroup"
-                local-group-prefix :local]
-            (augroup! group-name
-              (au! [:FileType]
-                   #(buf-augroup! local-group-prefix
-                      (au! [:InsertEnter] [:buffer 0 :desc "spawned autocmd"]
-                           (fn [a]
-                             (buf-autocmd!/with-buffer=0 a.group [:BufWritePre]
-                                                         default-callback
-                                                         {:desc "spawned autocmd, nested"}))))))
-            (let [[au &as aus] (get-autocmds {:group group-name})]
-              (assert.is_same 1 (length aus))
-              (assert.is_same :FileType au.event))
-            (set vim.bo.filetype :foo)
-            (var ie nil)
-            (let [buffer (vim.api.nvim_get_current_buf)
-                  macro-gen-group-name (.. local-group-prefix buffer)]
-              (let [[au1 &as aus] (get-autocmds {:group macro-gen-group-name
-                                                 : buffer})]
-                (assert.is_same 1 (length aus))
-                (assert.is_same :InsertEnter au1.event)
-                (set ie au1))
-              (vim.api.nvim_exec_autocmds :InsertEnter {: buffer})
-              (let [[au1 au2 &as aus] (get-autocmds {:group macro-gen-group-name
-                                                     : buffer})]
-                (assert.is_same ie.group_name au1.group_name)
-                (assert.is_same ie.group au1.group)
-                (assert.is_not_same ie.event au1.event)
-                (pending #(assert.is_same {:InsertEnter true :BufWritePre true}
-                                         {au1.event true au2.event true}))
-                (pending #(assert.is_same 2 (length aus))))))))
-      (describe "wrapper function at runtime"
-        (it "usually causes errors because compiled into unexpected output."
-          (autocmd! default-augroup [:FileType]
-                    (fn [au]
-                      (let [buf-local-augroup-name (: "buf-local-aug-%d"
-                                                      :format au.buf)
-                            buf-local-augroup-id (augroup! buf-local-augroup-name)]
-                        (fn buf-au! [buffer ...]
-                          (autocmd! buf-local-augroup-id ;
-                                    &default-opts {: buffer} ...))
+                      (. (get-first-autocmd {:pattern :pat}) :callback)))))
 
                         (assert.has.errors #(buf-au! [:InsertEnter]
                                                      default-callback)))

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -1,6 +1,8 @@
 (import-macros {: describe : it} :_busted_macros)
 (import-macros {: augroup! : au! : autocmd!} :nvim-laurel.macros)
-(import-macros {: augroup+} :_wrapper_macros)
+(import-macros {: my-autocmd! : augroup+ : buf-augroup!} :_wrapper_macros)
+
+(set _G.my-augroup-id (augroup! :MyAugroup))
 
 (macro macro-callback []
   `#:macro-callback)
@@ -189,7 +191,12 @@
             (augroup+ default-augroup
               (au! default-event [:pat1 :pat2] default-callback))
             (let [[autocmd] (get-autocmds)]
-              (assert.is.same default-callback autocmd.callback)))))
+              (assert.is.same default-callback autocmd.callback))))
+        (it "can create autocmd in predefined augroup in global-scope"
+          (assert.has_no_error #(my-autocmd! [:FileType] [:foo] default-command))
+          (let [[au &as aus] (get-autocmds {:group _G.my-augroup-id})]
+            (assert.is_same 1 (length aus))
+            (assert.is_same :foo au.pattern))))
       (describe "local macro"
         (describe "carefully binding variables without gensym"
           (it "can define buffer-local autocmd wrapper"

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -259,9 +259,10 @@
               (au! [:FileType]
                    #(buf-augroup! local-group-prefix
                       (au! [:InsertEnter] [:<buffer> :desc "spawned autocmd"]
-                           #(buf-autocmd!/with-buffer=0 $.group [:BufWritePre]
-                                                        default-callback
-                                                        {:desc "spawned autocmd, nested"})))))
+                           (fn [a]
+                             (buf-autocmd!/with-buffer=0 a.group [:BufWritePre]
+                                                         default-callback
+                                                         {:desc "spawned autocmd, nested"}))))))
             (let [[au &as aus] (get-autocmds {:group group-name})]
               (assert.is_same 1 (length aus))
               (assert.is_same :FileType au.event))

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -179,53 +179,54 @@
   ;;     ;; TODO: (it "in sequential format")))
   ;; (describe "lets augroup spawn buffer-local autocmds in buffer-local augroup")
   (describe "(wrapper)"
-    (describe "imported macro"
-      (describe :augroup+
-        (it "gets an existing augroup id"
-          (let [id (augroup! default-augroup)]
-            (assert.is.same id (augroup+ default-augroup))))
-        (it "can add autocmds to an existing augroup within `augroup+`"
-          (augroup+ default-augroup
-            (au! default-event [:pat1 :pat2] default-callback))
-          (let [[autocmd] (get-autocmds)]
-            (assert.is.same default-callback autocmd.callback)))))
-    (describe "local macro"
-      (describe "autocmd! wrapper function at runtime"
-        (it "usually causes errors because compiled into unexpected output."
-          (var foo false)
-          (autocmd! default-augroup [:FileType]
-                    (fn [au]
-                      (let [buf-local-augroup-name (: "buf-local-aug-%d"
-                                                      :format au.buf)
-                            buf-local-augroup-id (augroup! buf-local-augroup-name)]
-                        (fn buf-au! [bufnr ...]
-                          (autocmd! buf-local-augroup-id ;
-                                    &default-opts {:buffer bufnr} ...))
+    (describe "with `&default-opts`,"
+      (describe "imported macro"
+        (describe :augroup+
+          (it "gets an existing augroup id"
+            (let [id (augroup! default-augroup)]
+              (assert.is.same id (augroup+ default-augroup))))
+          (it "can add autocmds to an existing augroup within `augroup+`"
+            (augroup+ default-augroup
+              (au! default-event [:pat1 :pat2] default-callback))
+            (let [[autocmd] (get-autocmds)]
+              (assert.is.same default-callback autocmd.callback)))))
+      (describe "local macro"
+        (describe "autocmd! wrapper function at runtime"
+          (it "usually causes errors because compiled into unexpected output."
+            (var foo false)
+            (autocmd! default-augroup [:FileType]
+                      (fn [au]
+                        (let [buf-local-augroup-name (: "buf-local-aug-%d"
+                                                        :format au.buf)
+                              buf-local-augroup-id (augroup! buf-local-augroup-name)]
+                          (fn buf-au! [bufnr ...]
+                            (autocmd! buf-local-augroup-id ;
+                                      &default-opts {:buffer bufnr} ...))
 
-                        (assert.has.errors #(buf-au! [:InsertEnter]
-                                                     [:desc
-                                                      "Set `foo` to true"]
-                                                     #(set foo true)))
-                        (assert.has.errors #(buf-au! [:InsertLeave]
-                                                     #(let [filetype (. vim.b
-                                                                        au.buf
-                                                                        :filetype)]
-                                                        (set foo filetype))
-                                                     {:desc "Set `foo` to buffer filetype"})))
-                      (let [buf-local-augroup-name (: "another-buf-local-aug-%d"
-                                                      :format au.buf)
-                            buf-local-augroup-id (augroup! buf-local-augroup-name)]
-                        (fn buf-au! [bufnr ...]
-                          (autocmd! &default-opts {:buffer bufnr}
-                                    buf-local-augroup-id ...))
+                          (assert.has.errors #(buf-au! [:InsertEnter]
+                                                       [:desc
+                                                        "Set `foo` to true"]
+                                                       #(set foo true)))
+                          (assert.has.errors #(buf-au! [:InsertLeave]
+                                                       #(let [filetype (. vim.b
+                                                                          au.buf
+                                                                          :filetype)]
+                                                          (set foo filetype))
+                                                       {:desc "Set `foo` to buffer filetype"})))
+                        (let [buf-local-augroup-name (: "another-buf-local-aug-%d"
+                                                        :format au.buf)
+                              buf-local-augroup-id (augroup! buf-local-augroup-name)]
+                          (fn buf-au! [bufnr ...]
+                            (autocmd! &default-opts {:buffer bufnr}
+                                      buf-local-augroup-id ...))
 
-                        (assert.has.errors #(buf-au! [:InsertEnter]
-                                                     [:desc
-                                                      "Set `foo` to true"]
-                                                     #(set foo true)))
-                        (assert.has.errors #(buf-au! [:InsertLeave]
-                                                     #(let [filetype (. vim.b
-                                                                        au.buf
-                                                                        :filetype)]
-                                                        (set foo filetype))
-                                                     {:desc "Set `foo` to buffer filetype"}))))))))))
+                          (assert.has.errors #(buf-au! [:InsertEnter]
+                                                       [:desc
+                                                        "Set `foo` to true"]
+                                                       #(set foo true)))
+                          (assert.has.errors #(buf-au! [:InsertLeave]
+                                                       #(let [filetype (. vim.b
+                                                                          au.buf
+                                                                          :filetype)]
+                                                          (set foo filetype))
+                                                       {:desc "Set `foo` to buffer filetype"})))))))))))

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -251,7 +251,6 @@
               (assert.has_error #(set vim.bo.filetype :foobar))))))
       (describe "wrapper function at runtime"
         (it "usually causes errors because compiled into unexpected output."
-          (var foo false)
           (autocmd! default-augroup [:FileType]
                     (fn [au]
                       (let [buf-local-augroup-name (: "buf-local-aug-%d"
@@ -262,29 +261,12 @@
                                     &default-opts {:buffer bufnr} ...))
 
                         (assert.has.errors #(buf-au! [:InsertEnter]
-                                                     [:desc
-                                                      "Set `foo` to true"]
-                                                     #(set foo true)))
-                        (assert.has.errors #(buf-au! [:InsertLeave]
-                                                     #(let [filetype (. vim.b
-                                                                        au.buf
-                                                                        :filetype)]
-                                                        (set foo filetype))
-                                                     {:desc "Set `foo` to buffer filetype"})))
+                                                     default-callback)))
                       (let [buf-local-augroup-name (: "another-buf-local-aug-%d"
                                                       :format au.buf)
-                            buf-local-augroup-id (augroup! buf-local-augroup-name)]
-                        (fn buf-au! [bufnr ...]
-                          (autocmd! &default-opts {:buffer bufnr}
-                                    buf-local-augroup-id ...))
-
+                            buf-local-augroup-id (augroup! buf-local-augroup-name)
+                            buf-au! (fn [bufnr ...]
+                                      (autocmd! &default-opts {:buffer bufnr}
+                                                buf-local-augroup-id ...))]
                         (assert.has.errors #(buf-au! [:InsertEnter]
-                                                     [:desc
-                                                      "Set `foo` to true"]
-                                                     #(set foo true)))
-                        (assert.has.errors #(buf-au! [:InsertLeave]
-                                                     #(let [filetype (. vim.b
-                                                                        au.buf
-                                                                        :filetype)]
-                                                        (set foo filetype))
-                                                     {:desc "Set `foo` to buffer filetype"}))))))))))
+                                                     default-callback))))))))))

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -232,8 +232,8 @@
                 (assert.is_same :FileType au.event))
               (set vim.bo.filetype :foo)
               (let [bufnr (vim.api.nvim_get_current_buf)
-                    [au &as aus] (get-autocmds {:group (.. local-group-prefix
-                                                           bufnr)})]
+                    macro-gen-group-name (.. local-group-prefix bufnr)
+                    [au &as aus] (get-autocmds {:group macro-gen-group-name})]
                 (assert.is_same 1 (length aus))
                 (assert.is_same au.event :InsertEnter))))
           (pending "can spawn buffer-local autocmd from a spawned buffer-local augroup"))

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -43,6 +43,8 @@
 (lambda get-first-autocmd [?opts]
   (. (get-autocmds ?opts) 1))
 
+(var default-augroup-id nil)
+
 (var au-id1 nil)
 (var au-id2 nil)
 (var au-id3 nil)
@@ -58,7 +60,7 @@
   (teardown (fn []
               (vim.cmd "delfunction g:Test")))
   (before_each (fn []
-                 (augroup! default-augroup)
+                 (set default-augroup-id (augroup! default-augroup))
                  (let [aus (get-autocmds {})]
                    (assert.is_nil (next aus)))))
   (after_each (fn []

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -16,8 +16,11 @@
 (macro macro-command []
   :macro-command)
 
+(local get-autocmds vim.api.nvim_get_autocmds)
 (local del-autocmd vim.api.nvim_del_autocmd)
 (local exec-autocmds vim.api.nvim_exec_autocmds)
+(local del-augroup-by-id vim.api.nvim_del_augroup_by_id)
+(local del-augroup-by-name vim.api.nvim_del_augroup_by_name)
 
 (local default-augroup :default-test-augroup)
 (local default-event :BufRead)
@@ -28,22 +31,11 @@
 (local <default>-command :<default>-command)
 (local <default>-str-callback #:<default>-str-callback)
 
-(lambda get-autocmds [?opts]
-  (let [opts (collect [k v (pairs (or ?opts {})) ;
-                       &into {:group default-augroup}]
-               (values k v))]
-    ;; Note: `vim.api.nvim_get_autocmds` would includes the autocmds defined
-    ;; in running nvim when the tests are run in a local nvim instance.
-    (when (= false opts.group)
-      (set opts.group nil))
-    ;; Note: The order of the result list is not always in the order of
-    ;; definitions.
-    (vim.api.nvim_get_autocmds opts)))
-
 (lambda get-first-autocmd [?opts]
   (. (get-autocmds ?opts) 1))
 
 (var default-augroup-id nil)
+(var another-augroup-name nil)
 
 (var au-id1 nil)
 (var au-id2 nil)
@@ -60,6 +52,9 @@
   (teardown (fn []
               (vim.cmd "delfunction g:Test")))
   (before_each (fn []
+                 (when another-augroup-name
+                   (del-augroup-by-name another-augroup-name)
+                   (set another-augroup-name nil))
                  (set default-augroup-id (augroup! default-augroup))
                  (let [aus (get-autocmds {})]
                    (assert.is_nil (next aus)))))
@@ -70,9 +65,9 @@
   (describe :augroup!
     (it "returns augroup id without autocmds insides"
       (let [id (augroup! default-augroup)]
-        (assert.has_no.errors #(vim.api.nvim_del_augroup_by_id id))))
+        (assert.has_no_errors #(del-augroup-by-id id))))
     (it "can create augroup with `au!` macro and sequence without `au!` macro mixed"
-      (assert.has_no.errors #(augroup! default-augroup
+      (assert.has_no_errors #(augroup! default-augroup
                                [default-event default-callback]
                                (au! :FileType [:foo :bar] #:foobar)
                                [default-event default-callback]
@@ -102,53 +97,257 @@
           (let [aus (vim.api.nvim_get_autocmds {:event [:BufWritePre]})]
             (assert.is_same 1 (length aus)))))
       (it "callback arg value at `group` is same as the parent group id."
-        (let [local-group "local group"
-              group-id (augroup! local-group)
-              s (spy.new)]
+        (let [s (spy.new)]
           (set au-id1
-              (au! local-group [:InsertEnter]
+               (au! default-augroup [:InsertEnter]
                     [:buffer 0 :desc "spawned autocmd"]
                     (fn [a]
-                      (assert.is_same group-id a.group)
+                      (assert.is_same default-augroup-id a.group)
                       (s)
                       (set au-id2
-                          (autocmd! a.group [:BufWritePre] [:buffer 0]
-                                    default-callback
-                                    {:desc "spawned autocmd, nested"})))))
+                           (autocmd! a.group [:BufWritePre] [:buffer 0]
+                                     default-callback
+                                     {:desc "spawned autocmd, nested"})))))
           (assert-spy s :was_not_called)
-          (exec-autocmds :InsertEnter {:group local-group})
+          (exec-autocmds :InsertEnter {:group default-augroup})
           (assert-spy s :was_called)
-          (let [[au1 au2 &as aus] (get-autocmds {:group local-group})]
+          (let [[au1 au2 &as aus] (get-autocmds {:group default-augroup})]
             (assert.is_same {:InsertEnter true :BufWritePre true}
                             {au1.event true au2.event true})
             (assert.is_same 2 (length aus)))))
       (it "callback arg value at `group` is same as the parent group id even inside `augroup!` macro."
-        (let [local-group "local group"
-              s (spy.new)]
-          (augroup! local-group
+        (let [s (spy.new)]
+          (augroup! default-augroup
             (au! [:InsertEnter] [:buffer 0 :desc "spawned autocmd"]
                  (fn [a]
                    (s)
-                   (autocmd! a.group [:BufWritePre] [:buffer 0] default-callback
-                             {:desc "spawned autocmd, nested"}))))
+                   (autocmd! a.group [:BufWritePre] [:buffer 0]
+                             default-callback {:desc "spawned autocmd, nested"}))))
           (assert-spy s :was_not_called)
-          (exec-autocmds :InsertEnter {:group local-group})
+          (exec-autocmds :InsertEnter {:group default-augroup})
           (assert-spy s :was_called)
-          (let [[au1 au2 &as aus] (vim.api.nvim_get_autocmds {:group local-group})]
+          (let [[au1 au2 &as aus] (vim.api.nvim_get_autocmds {:group default-augroup})]
             (assert.is_same {:InsertEnter true :BufWritePre true}
                             {au1.event true au2.event true})
             (assert.is_same 2 (length aus))))))
     (it "should set callback via macro"
       (let [desc "macro callback"]
-        (set au-id1 (autocmd! default-augroup default-event [:pat] [:desc desc]
-                              (macro-callback)))
+        (autocmd! default-augroup default-event [:pat] [:desc desc]
+                  (macro-callback))
         (let [au (get-first-autocmd {:pattern :pat})]
           (assert.is_same desc au.desc))))
     (it "should set callback function in symbol"
-      (set au-id1 (autocmd! default-augroup default-event [:pat]
-                            default-callback))
+      (autocmd! default-augroup default-event [:pat] default-callback)
       (assert.is_same default-callback
-                      (. (get-first-autocmd {:pattern :pat}) :callback)))))
+                      (. (get-first-autocmd {:pattern :pat}) :callback)))
+    (it "should set callback function in multi-symbol"
+      (let [desc :multi.sym]
+        (autocmd! default-augroup default-event [:pat] default.multi.sym
+                  {: desc})
+        ;; FIXME: In vusted, callback is unexpectedly set to a string
+        ;; "<vim function: default.multi.sym>"; it must be the same as
+        ;; `default.multi.sym`.
+        (assert.is_same desc (. (get-first-autocmd {:pattern :pat}) :desc))))
+    (it "should set callback function in list"
+      (let [desc :list]
+        (autocmd! default-augroup default-event [:pat]
+                  (default-callback :foo :bar) {: desc})
+        (let [au (get-first-autocmd {:pattern :pat})]
+          (assert.is_same desc au.desc))))
+    (it "should set vim.fn.Test in string \"Test\""
+      (autocmd! default-augroup default-event [:pat] vim.fn.Test)
+      (let [au (get-first-autocmd {:pattern :pat})]
+        (assert.is_same "<vim function: Test>" au.callback)))
+    (it "set #(vim.fn.Test) to callback without modification"
+      (autocmd! default-augroup default-event [:pat] #(vim.fn.Test))
+      (let [au (get-first-autocmd {:pattern :pat})]
+        (assert.is_not_same "<vim function: Test>" au.callback)))
+    (it "can add an autocmd to an existing augroup"
+      (autocmd! default-augroup default-event [:pat1 :pat2] default-callback)
+      (let [[au1] (get-autocmds {:group default-augroup})]
+        (assert.is_same default-callback au1.callback)))
+    (it "can add autocmd with no patterns for macro"
+      (assert.has_no.errors #(autocmd! default-augroup default-event
+                                       default-callback)))
+    (it "sets vim.fn.Test to callback in string"
+      (assert.has_no.errors #(autocmd! default-augroup default-event
+                                       vim.fn.Test))
+      (let [[autocmd] (get-autocmds {:group default-augroup})]
+        (assert.is.same "<vim function: Test>" autocmd.callback)))
+    (it "creates buffer-local autocmd with `buffer` key"
+      (let [buffer (vim.api.nvim_get_current_buf)
+            au1 (au! default-augroup default-event [:buffer buffer]
+                     default-callback)]
+        (vim.cmd.new)
+        (vim.cmd.only)
+        (let [au2 (au! default-augroup default-event [:<buffer>]
+                       default-callback)
+              [autocmd1] (get-autocmds {: buffer})
+              [autocmd2] ;
+              (get-autocmds {:buffer (vim.api.nvim_get_current_buf)})]
+          (assert.is.same au1 autocmd1.id)
+          (assert.is.same au2 autocmd2.id))))
+    (it "can define autocmd without any augroup"
+      (assert.has_no.errors #(let [id (au! nil default-event default-callback)]
+                               (vim.api.nvim_del_autocmd id))))
+    (it "gives lowest priority to `pattern` as (< raw seq tbl)"
+      (let [seq-pat :seq-pat
+            tbl-pat :tbl-pat]
+        (au! default-augroup default-event [:raw-seq-pat] default-callback)
+        (au! default-augroup default-event [:pattern seq-pat] default-callback)
+        (au! default-augroup default-event default-callback {:pattern tbl-pat})
+        (let [au (get-first-autocmd {:pattern [:raw-seq-pat]})]
+          (assert.is.same :raw-seq-pat au.pattern))
+        (let [au (get-first-autocmd {:pattern seq-pat})]
+          (assert.is.same seq-pat au.pattern))
+        (let [au (get-first-autocmd {:pattern tbl-pat})]
+          (assert.is.same tbl-pat au.pattern))))
+    (describe "detects 2 args:"
+      (it "sequence pattern and string callback"
+        (autocmd! default-augroup default-event [:pat] :callback))
+      (it "sequence pattern and function callback"
+        (autocmd! default-augroup default-event [:pat] #:callback))
+      (it "sequence pattern and symbol callback"
+        (let [cb :callback]
+          (autocmd! default-augroup default-event [:pat] cb)))
+      (it "extra-opts and string callback"
+        (autocmd! default-augroup default-event [:pat] :callback))
+      (it "extra-opts and function callback"
+        (autocmd! default-augroup default-event [:pat] #:callback))
+      (it "extra-opts and symbol callback"
+        (let [cb :callback]
+          (autocmd! default-augroup default-event [:pat] cb)))
+      (it "string callback and api-opts in table"
+        (autocmd! default-augroup default-event :callback {:nested true}))
+      (it "string callback and api-opts in symbol"
+        (let [opts {:nested true}]
+          (autocmd! default-augroup default-event :callback opts)))
+      (it "function callback and api-opts in table"
+        (autocmd! default-augroup default-event #:callback {:nested true}))
+      (it "function callback and api-opts in symbol"
+        (let [opts {:nested true}]
+          (autocmd! default-augroup default-event #:callback opts)))
+      (it "symbol callback and api-opts in table"
+        (let [cb :callback]
+          (autocmd! default-augroup default-event cb {:nested true})))
+      (it "symbol callback and api-opts in symbol"
+        (let [cb :callback
+              opts {:nested true}]
+          (autocmd! default-augroup default-event cb opts)))))
+  (describe :<Cmd>pattern
+    (it "symbol will be set to 'command'"
+      (au! default-augroup default-event [:pat1] <default>-command)
+      (let [au (get-first-autocmd {:pattern :pat1})]
+        (assert.is_same <default>-command au.command)))
+    (it "list will be set to 'command'"
+      (au! default-augroup default-event [:pat1] (<default>-str-callback))
+      (let [au (get-first-autocmd {:pattern :pat1})]
+        (assert.is_same (<default>-str-callback) au.command))))
+  (describe "with symbol &vim"
+    (it "should set symbol to `command`"
+      (au! default-augroup default-event [:pat1] &vim default-command)
+      (let [[autocmd1] (get-autocmds {:pattern :pat1})]
+        (assert.is_same default-command autocmd1.command)))
+    (it "should set list to `command`"
+      (autocmd! default-augroup default-event [:pat] &vim (macro-command))
+      (let [au (get-first-autocmd {:pattern :pat})]
+        (assert.is_same :macro-command au.command))))
+  (describe "(wrapper)"
+    (describe "with `&default-opts`,"
+      (describe "imported macro"
+        (describe :augroup+
+          (it "gets an existing augroup id"
+            (let [id (augroup! default-augroup)]
+              (assert.is_same id (augroup+ default-augroup))))
+          (it "can add autocmds to an existing augroup within `augroup+`"
+            (augroup+ default-augroup
+              (au! default-event [:pat1 :pat2] default-callback))
+            (let [[autocmd] (get-autocmds {:group default-augroup})]
+              (assert.is_same default-callback autocmd.callback))))
+        (it "can create autocmd in predefined augroup in global-scope"
+          (set au-id1 (my-autocmd! [:FileType] [:foo] default-callback))
+          (let [[au &as aus] (get-autocmds {:group _G.my-augroup-id})]
+            (assert.is_same 1 (length aus))
+            (assert.is_same :foo au.pattern))))
+      (describe "local macro"
+        (describe "carefully binding variables without gensym in order to get conflicted with existing variable"
+          ;; Note: Another spec, carelessly bound to undefined variable,
+          ;; throws error too earlier in nvim >= 0.10.
+          (it "can define buffer-local autocmd wrapper"
+            (var foo false)
+            (let [id (augroup! default-augroup)]
+              (macro buf-au! [...]
+                `(autocmd! id &default-opts {:buffer a.buf} ,...))
+              (assert.is_false foo)
+              (autocmd! id [:FileType] [:foobar]
+                        (fn [a]
+                          (buf-au! [:InsertEnter] #(set foo true))))
+              (assert.is_false foo)
+              (let [buffer (vim.api.nvim_get_current_buf)]
+                (set vim.bo.filetype :foobar)
+                (assert.is_false foo)
+                (vim.api.nvim_exec_autocmds :InsertEnter {: buffer})
+                (assert.is_true foo)
+                (let [[au1 &as aus] (get-autocmds {:group id : buffer})]
+                  (assert.is_same 1 (length aus))
+                  (assert.is_same :InsertEnter au1.event)
+                  (assert.is_same buffer au1.buffer)))))
+          (it "can spawn a buffer-local augroup"
+            (let [local-group-prefix :local
+                  bufnr (vim.api.nvim_get_current_buf)]
+              (augroup! default-augroup
+                (au! [:FileType]
+                     #(buf-augroup! local-group-prefix
+                        (au! [:InsertEnter] [:<buffer>] default-callback))))
+              (let [[au &as aus] (get-autocmds {:group default-augroup})]
+                (assert.is_same 1 (length aus))
+                (assert.is_same :FileType au.event))
+              (set vim.bo.filetype :foo)
+              (set another-augroup-name (.. local-group-prefix bufnr))
+              (let [[au1 &as aus] (get-autocmds {:group another-augroup-name})]
+                (assert.is_same 1 (length aus))
+                (assert.is_same :InsertEnter au1.event)))))
+        (it "can spawn buffer-local autocmd from a spawned buffer-local augroup"
+          (let [local-group-prefix :local]
+            (augroup! default-augroup
+              (au! [:FileType]
+                   #(buf-augroup! local-group-prefix
+                      (au! [:InsertEnter] [:buffer 0 :desc "spawned autocmd"]
+                           (fn [a]
+                             (buf-autocmd!/with-buffer=0 a.group [:BufWritePre]
+                                                         default-callback
+                                                         {:desc "spawned autocmd, nested"}))))))
+            (let [[au &as aus] (get-autocmds {:group default-augroup})]
+              (assert.is_same 1 (length aus))
+              (assert.is_same :FileType au.event))
+            (set vim.bo.filetype :foo)
+            (var ie nil)
+            (let [buffer (vim.api.nvim_get_current_buf)]
+              (set another-augroup-name (.. local-group-prefix buffer))
+              (let [[au1 &as aus] (get-autocmds {:group another-augroup-name
+                                                 : buffer})]
+                (assert.is_same 1 (length aus))
+                (assert.is_same :InsertEnter au1.event)
+                (set ie au1))
+              (vim.api.nvim_exec_autocmds :InsertEnter {: buffer})
+              (let [[au1 au2 &as aus] (get-autocmds {:group another-augroup-name
+                                                     : buffer})]
+                (assert.is_same ie.group_name au1.group_name)
+                (assert.is_same ie.group au1.group)
+                (assert.is_not_same ie.event au1.event)
+                (assert.is_same {:InsertEnter true :BufWritePre true}
+                                {au1.event true au2.event true})
+                (assert.is_same 2 (length aus)))))))
+      (describe "wrapper function at runtime"
+        (it "usually causes errors because compiled into unexpected output."
+          (autocmd! default-augroup [:FileType]
+                    (fn [au]
+                      (let [buf-local-augroup-name (: "buf-local-aug-%d"
+                                                      :format au.buf)
+                            buf-local-augroup-id (augroup! buf-local-augroup-name)]
+                        (fn buf-au! [buffer ...]
+                          (autocmd! buf-local-augroup-id ;
+                                    &default-opts {: buffer} ...))
 
                         (assert.has.errors #(buf-au! [:InsertEnter]
                                                      default-callback)))

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -119,6 +119,58 @@
             (assert.is_same 2 (length aus)))))
       (it "callback arg value at `group` is same as the parent group id even inside `augroup!` macro."
         (let [s (spy.new)]
+          (set another-augroup-name :foobar)
+          (augroup! another-augroup-name
+            (au! [:VimEnter] (do
+                               :dummy)))
+          (augroup! default-augroup
+            (au! [:BufReadPost] (do
+                                  :dummy))
+            (au! [:InsertEnter] [:desc "spawned autocmd"]
+                 (fn [a]
+                   (assert.is_same default-augroup-id a.group)
+                   (s)
+                   (autocmd! a.group [:BufWritePre] default-callback
+                             {:desc "spawned autocmd, nested"})
+                   (autocmd! a.group [:CmdlineEnter] default-callback
+                             {:desc "spawned autocmd, nested"})
+                   (autocmd! a.group [:TextChangedI] default-callback
+                             {:desc "spawned autocmd, nested"}))))
+          (let [[au1 au2 &as aus] (get-autocmds {:group default-augroup})]
+            (assert.is_same {:InsertEnter true :BufReadPost true}
+                            {au1.event true au2.event true})
+            (assert.is_same 2 (length aus)))
+          (assert-spy s :was_not_called)
+          (exec-autocmds :InsertEnter {:group default-augroup})
+          (assert-spy s :was_called)
+          (pending #(let [[au1 au2 au3 au4 au5 au6 &as aus] (get-autocmds {})]
+                      (assert.is_same {:InsertEnter true
+                                       :BufReadPost true
+                                       :VimEnter true
+                                       :BufWritePre true
+                                       :CmdlineEnter true
+                                       :TextChangedI true}
+                                      {au1.event true
+                                       au2.event true
+                                       au3.event true
+                                       au4.event true
+                                       au5.event true
+                                       au6.event true})
+                      (assert.is_same 6 (length aus))))
+          (pending #(let [[au1 au2 au3 au4 au5 &as aus] (get-autocmds {:group default-augroup})]
+                      (assert.is_same {:InsertEnter true
+                                       :BufReadPost true
+                                       :BufWritePre true
+                                       :CmdlineEnter true
+                                       :TextChangedI true}
+                                      {au1.event true
+                                       au2.event true
+                                       au3.event true
+                                       au4.event true
+                                       au5.event true})
+                      (assert.is_same 5 (length aus))))))
+      (it "callback arg value at `group` is same as the parent group id even inside `augroup!` macro with 'buffer' key assigned."
+        (let [s (spy.new)]
           (augroup! default-augroup
             (au! [:InsertEnter] [:buffer 0 :desc "spawned autocmd"]
                  (fn [a]

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -34,6 +34,8 @@
 (lambda get-first-autocmd [?opts]
   (. (get-autocmds ?opts) 1))
 
+;; Note: `(vim.cmd "normal! i")` does not trigger event InsertEnter in the
+;; nvim nightly v0.10; use `(vim.fn.feedkeys :i :ni)` instead.
 (describe :autocmd
   (setup (fn []
            (vim.cmd "function g:Test() abort\nendfunction")))
@@ -220,7 +222,7 @@
               (assert.is_false foo)
               (set vim.bo.filetype :foobar)
               (assert.is_false foo)
-              (vim.cmd.normal {:args [:i] :bang true})
+              (vim.fn.feedkeys :i :ni)
               (assert.is_true foo)
               (let [bufnr (vim.api.nvim_get_current_buf)
                     [au1 au2 &as aus] (get-autocmds {:group id})]

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -27,6 +27,8 @@
     ;; in running nvim when the tests are run in a local nvim instance.
     (when (= false opts.group)
       (set opts.group nil))
+    ;; Note: The order of the result list is not always in the order of
+    ;; definitions.
     (vim.api.nvim_get_autocmds opts)))
 
 (lambda get-first-autocmd [?opts]

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -133,8 +133,6 @@
                    (autocmd! a.group [:BufWritePre] default-callback
                              {:desc "spawned autocmd, nested"})
                    (autocmd! a.group [:CmdlineEnter] default-callback
-                             {:desc "spawned autocmd, nested"})
-                   (autocmd! a.group [:TextChangedI] default-callback
                              {:desc "spawned autocmd, nested"}))))
           (let [[au1 au2 &as aus] (get-autocmds {:group default-augroup})]
             (assert.is_same {:InsertEnter true :BufReadPost true}
@@ -143,32 +141,28 @@
           (assert-spy s :was_not_called)
           (exec-autocmds :InsertEnter {:group default-augroup})
           (assert-spy s :was_called)
-          (pending #(let [[au1 au2 au3 au4 au5 au6 &as aus] (get-autocmds {})]
+          (pending #(let [[au1 au2 au3 au4 au5 &as aus] (get-autocmds {})]
                       (assert.is_same {:InsertEnter true
                                        :BufReadPost true
                                        :VimEnter true
                                        :BufWritePre true
-                                       :CmdlineEnter true
-                                       :TextChangedI true}
-                                      {au1.event true
-                                       au2.event true
-                                       au3.event true
-                                       au4.event true
-                                       au5.event true
-                                       au6.event true})
-                      (assert.is_same 6 (length aus))))
-          (pending #(let [[au1 au2 au3 au4 au5 &as aus] (get-autocmds {:group default-augroup})]
-                      (assert.is_same {:InsertEnter true
-                                       :BufReadPost true
-                                       :BufWritePre true
-                                       :CmdlineEnter true
-                                       :TextChangedI true}
+                                       :CmdlineEnter true}
                                       {au1.event true
                                        au2.event true
                                        au3.event true
                                        au4.event true
                                        au5.event true})
-                      (assert.is_same 5 (length aus))))))
+                      (assert.is_same 5 (length aus))))
+          (pending #(let [[au1 au2 au3 au4 &as aus] (get-autocmds {:group default-augroup})]
+                      (assert.is_same {:InsertEnter true
+                                       :BufReadPost true
+                                       :BufWritePre true
+                                       :CmdlineEnter true}
+                                      {au1.event true
+                                       au2.event true
+                                       au3.event true
+                                       au4.event true})
+                      (assert.is_same 4 (length aus))))))
       (it "callback arg value at `group` is same as the parent group id even inside `augroup!` macro with 'buffer' key assigned."
         (let [s (spy.new)]
           (augroup! default-augroup

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -174,6 +174,7 @@
           (augroup! default-augroup
             (au! [:InsertEnter] [:buffer 0 :desc "spawned autocmd"]
                  (fn [a]
+                   (assert.is_same default-augroup-id a.group)
                    (s)
                    (autocmd! a.group [:BufWritePre] [:buffer 0]
                              default-callback {:desc "spawned autocmd, nested"}))))

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -219,7 +219,14 @@
               (set vim.bo.filetype :foobar)
               (assert.is_false foo)
               (vim.cmd.normal {:args [:i] :bang true})
-              (assert.is_true foo)))
+              (assert.is_true foo)
+              (let [bufnr (vim.api.nvim_get_current_buf)
+                    [au1 au2 &as aus] (get-autocmds {:group id})]
+                (assert.is_same 2 (length aus))
+                (assert.is_same :FileType au1.event)
+                (assert.is_same :InsertEnter au2.event)
+                (assert.is_nil au1.buffer)
+                (assert.is_same bufnr au2.buffer))))
           (it "can spawn a buffer-local augroup"
             (let [group-name "spawn buffer-local augroup"
                   local-group-prefix :local]
@@ -233,10 +240,9 @@
               (set vim.bo.filetype :foo)
               (let [bufnr (vim.api.nvim_get_current_buf)
                     macro-gen-group-name (.. local-group-prefix bufnr)
-                    [au &as aus] (get-autocmds {:group macro-gen-group-name})]
+                    [au1 &as aus] (get-autocmds {:group macro-gen-group-name})]
                 (assert.is_same 1 (length aus))
-                (assert.is_same au.event :InsertEnter))))
-          (pending "can spawn buffer-local autocmd from a spawned buffer-local augroup"))
+                (assert.is_same :InsertEnter au1.event)))))
         (describe "**carelessly** binding variables without gensym"
           (it "throws error on wrapped autocmd triggered"
             (var foo false)

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -125,6 +125,9 @@
                    (s)
                    (autocmd! a.group [:BufWritePre] [:buffer 0]
                              default-callback {:desc "spawned autocmd, nested"}))))
+          (let [[au1 &as aus] (get-autocmds {:group default-augroup})]
+            (assert.is_same {:InsertEnter true} {au1.event true})
+            (assert.is_same 1 (length aus)))
           (assert-spy s :was_not_called)
           (exec-autocmds :InsertEnter {:group default-augroup})
           (assert-spy s :was_called)

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -179,49 +179,53 @@
   ;;     ;; TODO: (it "in sequential format")))
   ;; (describe "lets augroup spawn buffer-local autocmds in buffer-local augroup")
   (describe "(wrapper)"
-    (describe :augroup+
-      (it "gets an existing augroup id"
-        (let [id (augroup! default-augroup)]
-          (assert.is.same id (augroup+ default-augroup))))
-      (it "can add autocmds to an existing augroup within `augroup+`"
-        (augroup+ default-augroup
-          (au! default-event [:pat1 :pat2] default-callback))
-        (let [[autocmd] (get-autocmds)]
-          (assert.is.same default-callback autocmd.callback))))
-    (describe "autocmd! wrapper function at runtime"
-      (it "usually causes errors because compiled into unexpected output."
-        (var foo false)
-        (autocmd! default-augroup [:FileType]
-                  (fn [au]
-                    (let [buf-local-augroup-name (: "buf-local-aug-%d" :format
-                                                    au.buf)
-                          buf-local-augroup-id (augroup! buf-local-augroup-name)]
-                      (fn buf-au! [bufnr ...]
-                        (autocmd! buf-local-augroup-id ;
-                                  &default-opts {:buffer bufnr} ...))
+    (describe "imported macro"
+      (describe :augroup+
+        (it "gets an existing augroup id"
+          (let [id (augroup! default-augroup)]
+            (assert.is.same id (augroup+ default-augroup))))
+        (it "can add autocmds to an existing augroup within `augroup+`"
+          (augroup+ default-augroup
+            (au! default-event [:pat1 :pat2] default-callback))
+          (let [[autocmd] (get-autocmds)]
+            (assert.is.same default-callback autocmd.callback)))))
+    (describe "local macro"
+      (describe "autocmd! wrapper function at runtime"
+        (it "usually causes errors because compiled into unexpected output."
+          (var foo false)
+          (autocmd! default-augroup [:FileType]
+                    (fn [au]
+                      (let [buf-local-augroup-name (: "buf-local-aug-%d"
+                                                      :format au.buf)
+                            buf-local-augroup-id (augroup! buf-local-augroup-name)]
+                        (fn buf-au! [bufnr ...]
+                          (autocmd! buf-local-augroup-id ;
+                                    &default-opts {:buffer bufnr} ...))
 
-                      (assert.has.errors #(buf-au! [:InsertEnter]
-                                                   [:desc "Set `foo` to true"]
-                                                   #(set foo true)))
-                      (assert.has.errors #(buf-au! [:InsertLeave]
-                                                   #(let [filetype (. vim.b
-                                                                      au.buf
-                                                                      :filetype)]
-                                                      (set foo filetype))
-                                                   {:desc "Set `foo` to buffer filetype"})))
-                    (let [buf-local-augroup-name (: "another-buf-local-aug-%d"
-                                                    :format au.buf)
-                          buf-local-augroup-id (augroup! buf-local-augroup-name)]
-                      (fn buf-au! [bufnr ...]
-                        (autocmd! &default-opts {:buffer bufnr}
-                                  buf-local-augroup-id ...))
+                        (assert.has.errors #(buf-au! [:InsertEnter]
+                                                     [:desc
+                                                      "Set `foo` to true"]
+                                                     #(set foo true)))
+                        (assert.has.errors #(buf-au! [:InsertLeave]
+                                                     #(let [filetype (. vim.b
+                                                                        au.buf
+                                                                        :filetype)]
+                                                        (set foo filetype))
+                                                     {:desc "Set `foo` to buffer filetype"})))
+                      (let [buf-local-augroup-name (: "another-buf-local-aug-%d"
+                                                      :format au.buf)
+                            buf-local-augroup-id (augroup! buf-local-augroup-name)]
+                        (fn buf-au! [bufnr ...]
+                          (autocmd! &default-opts {:buffer bufnr}
+                                    buf-local-augroup-id ...))
 
-                      (assert.has.errors #(buf-au! [:InsertEnter]
-                                                   [:desc "Set `foo` to true"]
-                                                   #(set foo true)))
-                      (assert.has.errors #(buf-au! [:InsertLeave]
-                                                   #(let [filetype (. vim.b
-                                                                      au.buf
-                                                                      :filetype)]
-                                                      (set foo filetype))
-                                                   {:desc "Set `foo` to buffer filetype"})))))))))
+                        (assert.has.errors #(buf-au! [:InsertEnter]
+                                                     [:desc
+                                                      "Set `foo` to true"]
+                                                     #(set foo true)))
+                        (assert.has.errors #(buf-au! [:InsertLeave]
+                                                     #(let [filetype (. vim.b
+                                                                        au.buf
+                                                                        :filetype)]
+                                                        (set foo filetype))
+                                                     {:desc "Set `foo` to buffer filetype"}))))))))))

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -108,14 +108,14 @@
       (let [[autocmd] (get-autocmds)]
         (assert.is.same "<vim function: Test>" autocmd.callback)))
     (it "creates buffer-local autocmd with `buffer` key"
-      (let [bufnr (vim.api.nvim_get_current_buf)
-            au1 (au! default-augroup default-event [:buffer bufnr]
+      (let [buffer (vim.api.nvim_get_current_buf)
+            au1 (au! default-augroup default-event [:buffer buffer]
                      default-callback)]
         (vim.cmd.new)
         (vim.cmd.only)
         (let [au2 (au! default-augroup default-event [:<buffer>]
                        default-callback)
-              [autocmd1] (get-autocmds {:buffer bufnr})
+              [autocmd1] (get-autocmds {: buffer})
               [autocmd2] ;
               (get-autocmds {:buffer (vim.api.nvim_get_current_buf)})]
           (assert.is.same au1 autocmd1.id)
@@ -225,15 +225,15 @@
                         (fn [a]
                           (buf-au! [:InsertEnter] #(set foo true))))
               (assert.is_false foo)
-              (let [bufnr (vim.api.nvim_get_current_buf)]
+              (let [buffer (vim.api.nvim_get_current_buf)]
                 (set vim.bo.filetype :foobar)
                 (assert.is_false foo)
-                (vim.api.nvim_exec_autocmds :InsertEnter {:buffer bufnr})
+                (vim.api.nvim_exec_autocmds :InsertEnter {: buffer})
                 (assert.is_true foo)
-                (let [[au1 &as aus] (get-autocmds {:group id :buffer bufnr})]
+                (let [[au1 &as aus] (get-autocmds {:group id : buffer})]
                   (assert.is_same 1 (length aus))
                   (assert.is_same :InsertEnter au1.event)
-                  (assert.is_same bufnr au1.buffer)))))
+                  (assert.is_same buffer au1.buffer)))))
           (it "can spawn a buffer-local augroup"
             (let [group-name "spawn buffer-local augroup"
                   local-group-prefix :local]
@@ -283,17 +283,17 @@
                       (let [buf-local-augroup-name (: "buf-local-aug-%d"
                                                       :format au.buf)
                             buf-local-augroup-id (augroup! buf-local-augroup-name)]
-                        (fn buf-au! [bufnr ...]
+                        (fn buf-au! [buffer ...]
                           (autocmd! buf-local-augroup-id ;
-                                    &default-opts {:buffer bufnr} ...))
+                                    &default-opts {: buffer} ...))
 
                         (assert.has.errors #(buf-au! [:InsertEnter]
                                                      default-callback)))
                       (let [buf-local-augroup-name (: "another-buf-local-aug-%d"
                                                       :format au.buf)
                             buf-local-augroup-id (augroup! buf-local-augroup-name)
-                            buf-au! (fn [bufnr ...]
-                                      (autocmd! &default-opts {:buffer bufnr}
+                            buf-au! (fn [buffer ...]
+                                      (autocmd! &default-opts {: buffer}
                                                 buf-local-augroup-id ...))]
                         (assert.has.errors #(buf-au! [:InsertEnter]
                                                      default-callback))))))))))

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -231,11 +231,11 @@
                 (assert.is_same 1 (length aus))
                 (assert.is_same :FileType au.event))
               (set vim.bo.filetype :foo)
-              (pending #(let [bufnr (vim.api.nvim_get_current_buf)
-                              [au &as aus] (get-autocmds {:event :InsertEnter})]
-                          (assert.is_same 1 (length aus))
-                          (assert.is_same au.group
-                                          (.. local-group-prefix bufnr))))))
+              (let [bufnr (vim.api.nvim_get_current_buf)
+                    [au &as aus] (get-autocmds {:group (.. local-group-prefix
+                                                           bufnr)})]
+                (assert.is_same 1 (length aus))
+                (assert.is_same au.event :InsertEnter))))
           (pending "can spawn buffer-local autocmd from a spawned buffer-local augroup"))
         (describe "**carelessly** binding variables without gensym"
           (it "throws error on wrapped autocmd triggered"

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -257,17 +257,23 @@
               (assert.is_same 1 (length aus))
               (assert.is_same :FileType au.event))
             (set vim.bo.filetype :foo)
+            (var ie nil)
             (let [buffer (vim.api.nvim_get_current_buf)
                   macro-gen-group-name (.. local-group-prefix buffer)]
-              (let [[au &as aus] (get-autocmds {:group macro-gen-group-name})]
+              (let [[au1 &as aus] (get-autocmds {:group macro-gen-group-name
+                                                 : buffer})]
                 (assert.is_same 1 (length aus))
-                (assert.is_same :InsertEnter au.event))
+                (assert.is_same :InsertEnter au1.event)
+                (set ie au1))
               (vim.api.nvim_exec_autocmds :InsertEnter {: buffer})
               (let [[au1 au2 &as aus] (get-autocmds {:group macro-gen-group-name
                                                      : buffer})]
-                (assert.is_same 2 (length aus))
-                (assert.is_same {:InsertEnter true :BufWritePre true}
-                                {au1.event true au2.event true}))))))
+                (assert.is_same ie.group_name au1.group_name)
+                (assert.is_same ie.group au1.group)
+                (assert.is_not_same ie.event au1.event)
+                (pending #(assert.is_same {:InsertEnter true :BufWritePre true}
+                                         {au1.event true au2.event true}))
+                (pending #(assert.is_same 2 (length aus))))))))
       (describe "wrapper function at runtime"
         (it "usually causes errors because compiled into unexpected output."
           (autocmd! default-augroup [:FileType]

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -212,7 +212,9 @@
             (assert.is_same 1 (length aus))
             (assert.is_same :foo au.pattern))))
       (describe "local macro"
-        (describe "carefully binding variables without gensym"
+        (describe "carefully binding variables without gensym in order to get conflicted with existing variable"
+          ;; Note: Another spec, carelessly bound to undefined variable,
+          ;; throws error too earlier in nvim >= 0.10.
           (it "can define buffer-local autocmd wrapper"
             (var foo false)
             (let [id (augroup! default-augroup)]
@@ -275,19 +277,7 @@
                   [au1 au2 &as aus] (get-autocmds {:group macro-gen-group-name})]
               (assert.is_same 2 (length aus))
               (assert.is_same {:InsertEnter true :BufWritePre true}
-                              {au1.event true au2.event true}))))
-        (describe "**carelessly** binding variables without gensym"
-          (it "throws error on wrapped autocmd triggered"
-            (var foo false)
-            (let [id (augroup! default-augroup)]
-              (macro buf-au! [...]
-                `(autocmd! id &default-opts {:buffer undefined-var.buf} ,...))
-              (assert.is_false foo)
-              (assert.has_no_error #(autocmd! id [:FileType] [:foobar]
-                                              (fn [_a]
-                                                (buf-au! [:InsertEnter]
-                                                         #(set foo true)))))
-              (assert.has_error #(set vim.bo.filetype :foobar))))))
+                              {au1.event true au2.event true})))))
       (describe "wrapper function at runtime"
         (it "usually causes errors because compiled into unexpected output."
           (autocmd! default-augroup [:FileType]

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -185,14 +185,6 @@
       (autocmd! default-augroup default-event [:pat] &vim (macro-command))
       (let [au (get-first-autocmd {:pattern :pat})]
         (assert.is_same :macro-command au.command))))
-  ;; (describe "(inline)"
-  ;;   (describe "autocmd with &default-opts"))
-  ;; (describe "helps to create MyVimrc augroup")
-  ;; (describe "buf-autocmd! defined on au-event(s)"
-  ;;   (describe "creates another autocommand")
-  ;;     ;; TODO: (it "in api-opts format")
-  ;;     ;; TODO: (it "in sequential format")))
-  ;; (describe "lets augroup spawn buffer-local autocmds in buffer-local augroup")
   (describe "(wrapper)"
     (describe "with `&default-opts`,"
       (describe "imported macro"

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -23,6 +23,10 @@
   (let [opts (collect [k v (pairs (or ?opts {})) ;
                        &into {:group default-augroup}]
                (values k v))]
+    ;; Note: `vim.api.nvim_get_autocmds` would includes the autocmds defined
+    ;; in running nvim when the tests are run in a local nvim instance.
+    (when (= false opts.group)
+      (set opts.group nil))
     (vim.api.nvim_get_autocmds opts)))
 
 (lambda get-first-autocmd [?opts]
@@ -36,6 +40,8 @@
   (before_each (fn []
                  (augroup! default-augroup)
                  (let [aus (get-autocmds)]
+                   ;; TODO: Automate to clear any autocmds.
+                   ;; (let [aus (get-autocmds {:group false})])
                    (assert.is.same {} aus))))
   (describe :augroup!
     (it "returns augroup id without autocmds insides"

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -199,7 +199,8 @@
             (let [[autocmd] (get-autocmds)]
               (assert.is.same default-callback autocmd.callback))))
         (it "can create autocmd in predefined augroup in global-scope"
-          (assert.has_no_error #(my-autocmd! [:FileType] [:foo] default-command))
+          (assert.has_no_error #(my-autocmd! [:FileType] [:foo]
+                                             default-callback))
           (let [[au &as aus] (get-autocmds {:group _G.my-augroup-id})]
             (assert.is_same 1 (length aus))
             (assert.is_same :foo au.pattern))))

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -8,8 +8,6 @@
 (macro macro-command []
   :macro-command)
 
-(local fmt string.format)
-
 (local default-augroup :default-test-augroup)
 (local default-event :BufRead)
 (local default-callback #:default-callback)
@@ -172,6 +170,14 @@
       (autocmd! default-augroup default-event [:pat] &vim (macro-command))
       (let [au (get-first-autocmd {:pattern :pat})]
         (assert.is_same :macro-command au.command))))
+  ;; (describe "(inline)"
+  ;;   (describe "autocmd with &default-opts"))
+  ;; (describe "helps to create MyVimrc augroup")
+  ;; (describe "buf-autocmd! defined on au-event(s)"
+  ;;   (describe "creates another autocommand")
+  ;;     ;; TODO: (it "in api-opts format")
+  ;;     ;; TODO: (it "in sequential format")))
+  ;; (describe "lets augroup spawn buffer-local autocmds in buffer-local augroup")
   (describe "(wrapper)"
     (describe :augroup+
       (it "gets an existing augroup id"
@@ -187,7 +193,8 @@
         (var foo false)
         (autocmd! default-augroup [:FileType]
                   (fn [au]
-                    (let [buf-local-augroup-name (fmt "buf-local-aug-%d" au.buf)
+                    (let [buf-local-augroup-name (: "buf-local-aug-%d" :format
+                                                    au.buf)
                           buf-local-augroup-id (augroup! buf-local-augroup-name)]
                       (fn buf-au! [bufnr ...]
                         (autocmd! buf-local-augroup-id ;
@@ -202,8 +209,8 @@
                                                                       :filetype)]
                                                       (set foo filetype))
                                                    {:desc "Set `foo` to buffer filetype"})))
-                    (let [buf-local-augroup-name (fmt "another-buf-local-aug-%d"
-                                                      au.buf)
+                    (let [buf-local-augroup-name (: "another-buf-local-aug-%d"
+                                                    :format au.buf)
                           buf-local-augroup-id (augroup! buf-local-augroup-name)]
                       (fn buf-au! [bufnr ...]
                         (autocmd! &default-opts {:buffer bufnr}

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -45,7 +45,9 @@
 ;; nvim nightly v0.10; use `vim.api.nvim_exec_autocmds` instead.
 (describe :autocmd
   (setup (fn []
-           (let [nvim-builtin-augroups [:nvim_cmdwin :nvim_terminal]]
+           (let [nvim-builtin-augroups [:nvim_cmdwin
+                                        :nvim_terminal
+                                        :nvim_swapfile]]
              (each [_ group (ipairs nvim-builtin-augroups)]
                (augroup! group)))
            (vim.cmd "function g:Test() abort\nendfunction")))

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -231,11 +231,11 @@
                 (vim.api.nvim_exec_autocmds :InsertEnter {:buffer bufnr})
                 (assert.is_true foo)
                 (let [[au1 au2 &as aus] (get-autocmds {:group id})]
-                  (assert.is_same 2 (length aus))
-                  (assert.is_same :FileType au1.event)
-                  (assert.is_same :InsertEnter au2.event)
-                  (assert.is_nil au1.buffer)
-                  (assert.is_same bufnr au2.buffer)))))
+                  (pending #(assert.is_same 2 (length aus)))
+                  (pending #(assert.is_same :FileType au1.event))
+                  (pending #(assert.is_same :InsertEnter au2.event))
+                  (pending #(assert.is_nil au1.buffer))
+                  (pending #(assert.is_same bufnr au2.buffer))))))
           (it "can spawn a buffer-local augroup"
             (let [group-name "spawn buffer-local augroup"
                   local-group-prefix :local]
@@ -271,12 +271,12 @@
                   macro-gen-group-name (.. local-group-prefix bufnr)]
               (let [[au &as aus] (get-autocmds {:group macro-gen-group-name})]
                 (assert.is_same 1 (length aus))
-                (assert.is_same :InsertEnter au.event))
-              (vim.api.nvim_exec_autocmds :InsertEnter {:buffer bufnr})
-              (let [[au1 au2 &as aus] (get-autocmds {:group macro-gen-group-name})]
-                (assert.is_same 2 (length aus))
-                (assert.is_same {:InsertEnter true :BufWritePre true}
-                                {au1.event true au2.event true}))))))
+                (assert.is_same :InsertEnter au.event))))))
+      (vim.api.nvim_exec_autocmds :InsertEnter {:buffer bufnr})
+      (let [[au1 au2 &as aus] (get-autocmds {:group macro-gen-group-name})]
+        (pending #(assert.is_same 2 (length aus)))
+        (pending #(assert.is_same {:InsertEnter true :BufWritePre true}
+                                  {au1.event true au2.event true})))
       (describe "wrapper function at runtime"
         (it "usually causes errors because compiled into unexpected output."
           (autocmd! default-augroup [:FileType]

--- a/tests/spec/command_spec.fnl
+++ b/tests/spec/command_spec.fnl
@@ -7,6 +7,12 @@
 (macro macro-command []
   :macro-command)
 
+(macro buf-command!/as-api-alias [bufnr ...]
+  `(command! &default-opts {:buffer ,bufnr} ,...))
+
+(macro buf-command!/current-buffer-by-default [...]
+  `(command! &default-opts {:buffer 0} ,...))
+
 (local default-callback #:default-callback)
 (local default {:multi {:sym #:default.multi.sym}})
 

--- a/tests/spec/highlight_spec.fnl
+++ b/tests/spec/highlight_spec.fnl
@@ -181,5 +181,5 @@
             (it "can remove bold option"
               (bold-highlight! test-hl-name
                                {:ctermfg 0 :ctermbg 255 :bold false})
-              (assert.falsy (-> (get-hl 0 {:name test-hl-name})
-                                (. :bold))))))))))
+              (assert.is_falsy (-> (get-hl 0 {:name test-hl-name})
+                                   (. :bold))))))))))

--- a/tests/spec/keymap_spec.fnl
+++ b/tests/spec/keymap_spec.fnl
@@ -222,8 +222,8 @@
         (nmap! :lhs [:expr :literal] :rhs)
         (let [{: replace_keycodes} (get-mapargs :n :lhs)]
           (assert.is_nil replace_keycodes))))
-    (describe "with `&default-opts`"
-      (describe "macro defined in another file"
+    (describe "with `&default-opts`,"
+      (describe "imported macro"
         (describe :remap!
           (it "creates recursive mapping by default"
             (let [mode :x

--- a/tests/spec/keymap_spec.fnl
+++ b/tests/spec/keymap_spec.fnl
@@ -182,111 +182,112 @@
       (assert.has_no.errors #(map! :n [:<buffer>] :lhs (<C-u> "Do something")))
       (assert.is.same ":<C-U>Do something<CR>" (buf-get-rhs 0 :n :lhs))))
   (describe "(wrapper)"
-    (describe :remap!
-      (it "creates recursive mapping by default"
-        (let [mode :x
-              modes [:n :o :t]]
-          (remap! mode :lhs :rhs)
-          (remap! modes :lhs :rhs)
-          (let [{: noremap} (get-mapargs mode :lhs)]
-            (assert.is.same 0 noremap))
-          (each [_ m (ipairs modes)]
-            (let [{: noremap} (get-mapargs m :lhs)]
-              (assert.is.same 0 noremap)))))
-      (it "can create non-recursive mappings by overriding option"
-        (let [mode :x
-              modes [:n :o :t]]
-          (map! mode [:noremap] :lhs :rhs)
-          (map! modes [:noremap] :lhs :rhs)
-          (let [{: noremap} (get-mapargs mode :lhs)]
-            (assert.is.same 1 noremap))
-          (each [_ m (ipairs modes)]
-            (let [{: noremap} (get-mapargs m :lhs)]
-              (assert.is.same 1 noremap))))))
-    (describe "buf-map! with {:buffer 0} in its default-opts"
-      (before_each (fn []
-                     (refresh-buffer)))
-      (it "creates current buffer-local mapping by default"
-        (let [mode :x
-              bufnr (vim.api.nvim_get_current_buf)]
-          (assert.is_nil (get-rhs mode :lhs))
-          (assert.is_nil (buf-get-rhs 0 mode :lhs))
-          (buf-map!/with-buffer=0 mode :lhs :rhs)
-          (assert.is_nil (get-rhs mode :lhs))
-          (assert.is_same :rhs (buf-get-rhs 0 mode :lhs))
-          (refresh-buffer)
-          (assert.is_nil (buf-get-rhs 0 mode :lhs))
-          (assert.is_same :rhs (buf-get-rhs bufnr mode :lhs)))))
-    (it "can create another buffer-local mapping by overriding option"
-      (let [mode :x
-            bufnr (vim.api.nvim_get_current_buf)]
-        (refresh-buffer)
-        (assert.is_nil (get-rhs mode :lhs))
-        (assert.is_nil (buf-get-rhs 0 mode :lhs))
-        (buf-map!/with-buffer=0 mode [:buffer bufnr] :lhs :rhs)
-        (assert.is_nil (get-rhs mode :lhs))
-        (assert.is_nil (buf-get-rhs 0 mode :lhs))
-        (refresh-buffer)
-        (assert.is_same :rhs (buf-get-rhs bufnr mode :lhs))))
-    (describe "buf-map! with {:<buffer> true} in its default-opts"
-      (it "creates current buffer-local mapping by default"
-        (let [bufnr (vim.api.nvim_get_current_buf)]
-          (assert.is_nil (get-rhs :x :lhs))
-          (assert.is_nil (buf-get-rhs 0 :x :lhs))
-          (buf-map!/with-<buffer>=true :x :lhs :rhs)
-          (assert.is_nil (get-rhs :x :lhs))
-          (assert.is_same :rhs (buf-get-rhs 0 :x :lhs))
-          (refresh-buffer)
-          (assert.is_nil (buf-get-rhs 0 :x :lhs))
-          (assert.is_same :rhs (buf-get-rhs bufnr :x :lhs))))
+    (describe "macro defined in another file"
+      (describe :remap!
+        (it "creates recursive mapping by default"
+          (let [mode :x
+                modes [:n :o :t]]
+            (remap! mode :lhs :rhs)
+            (remap! modes :lhs :rhs)
+            (let [{: noremap} (get-mapargs mode :lhs)]
+              (assert.is.same 0 noremap))
+            (each [_ m (ipairs modes)]
+              (let [{: noremap} (get-mapargs m :lhs)]
+                (assert.is.same 0 noremap)))))
+        (it "can create non-recursive mappings by overriding option"
+          (let [mode :x
+                modes [:n :o :t]]
+            (map! mode [:noremap] :lhs :rhs)
+            (map! modes [:noremap] :lhs :rhs)
+            (let [{: noremap} (get-mapargs mode :lhs)]
+              (assert.is.same 1 noremap))
+            (each [_ m (ipairs modes)]
+              (let [{: noremap} (get-mapargs m :lhs)]
+                (assert.is.same 1 noremap))))))
+      (describe "buf-map! with {:buffer 0} in its default-opts"
+        (before_each (fn []
+                       (refresh-buffer)))
+        (it "creates current buffer-local mapping by default"
+          (let [mode :x
+                bufnr (vim.api.nvim_get_current_buf)]
+            (assert.is_nil (get-rhs mode :lhs))
+            (assert.is_nil (buf-get-rhs 0 mode :lhs))
+            (buf-map!/with-buffer=0 mode :lhs :rhs)
+            (assert.is_nil (get-rhs mode :lhs))
+            (assert.is_same :rhs (buf-get-rhs 0 mode :lhs))
+            (refresh-buffer)
+            (assert.is_nil (buf-get-rhs 0 mode :lhs))
+            (assert.is_same :rhs (buf-get-rhs bufnr mode :lhs)))))
       (it "can create another buffer-local mapping by overriding option"
         (let [mode :x
               bufnr (vim.api.nvim_get_current_buf)]
+          (refresh-buffer)
           (assert.is_nil (get-rhs mode :lhs))
           (assert.is_nil (buf-get-rhs 0 mode :lhs))
-          (buf-map!/with-<buffer>=true mode [:buffer bufnr] :lhs :rhs)
+          (buf-map!/with-buffer=0 mode [:buffer bufnr] :lhs :rhs)
           (assert.is_nil (get-rhs mode :lhs))
-          (assert.is_same :rhs (buf-get-rhs 0 mode :lhs))
+          (assert.is_nil (buf-get-rhs 0 mode :lhs))
           (refresh-buffer)
-          (assert.is_nil (buf-get-rhs 0 :x :lhs))
-          (assert.is_same :rhs (buf-get-rhs bufnr mode :lhs)))))
-    (describe :omni-map!
-      (it "should map to lhs in any mode"
-        (each [_ mode (ipairs [:n :v :x :s :o :i :l :c :t])]
-          (assert.is_nil (get-rhs mode :lhs)))
-        (omni-map! :lhs :rhs)
-        (each [_ mode (ipairs [:n :v :x :s :o :i :l :c :t])]
-          (assert.is_same :rhs (get-rhs mode :lhs)))))
-    (describe :nmap!
-      (it "can include extra-opts in either first or second arg"
-        (assert.has_no.errors #(nmap! [:nowait] :lhs :rhs))
-        (assert.has_no.errors #(nmap! :lhs [:nowait] :rhs)))
-      (it "maps to current buffer with `<buffer>`"
-        (nmap! [:<buffer>] :lhs :rhs)
-        (assert.is.same :rhs (buf-get-rhs 0 :n :lhs)))
-      (it "maps to specific buffer with `buffer`"
-        (let [bufnr (vim.api.nvim_get_current_buf)]
-          (refresh-buffer)
-          (nmap! [:buffer bufnr] :lhs :rhs)
-          (assert.is_nil (buf-get-rhs 0 :n :lhs))
-          (assert.is.same :rhs (buf-get-rhs bufnr :n :lhs))))
-      (it "set a list which will result in string without callback"
-        (nmap! :lhs &vim (.. :r :h :s))
-        (nmap! :lhs1 &vim (.. (<Cmd> :foobar) :<Esc>))
-        (assert.is.same :rhs (get-rhs :n :lhs))
-        (assert.is.same :<Cmd>foobar<CR><Esc> (get-rhs :n :lhs1)))
-      (it "enables `replace_keycodes` when `expr` is set in `extra-opts`"
-        (nmap! :lhs [:expr] :rhs)
-        (nmap! :lhs1 :rhs {:expr true})
-        (let [opt {:expr true}]
-          (nmap! :lhs2 :rhs opt))
-        (let [{: replace_keycodes} (get-mapargs :n :lhs)]
-          (assert.is.same 1 replace_keycodes))
-        (let [{: replace_keycodes} (get-mapargs :n :lhs1)]
-          (assert.is_nil replace_keycodes))
-        (let [{: replace_keycodes} (get-mapargs :n :lhs2)]
-          (assert.is_nil replace_keycodes)))
-      (it "disables `replace_keycodes` when `literal` is set in `extra-opts`"
-        (nmap! :lhs [:expr :literal] :rhs)
-        (let [{: replace_keycodes} (get-mapargs :n :lhs)]
-          (assert.is_nil replace_keycodes))))))
+          (assert.is_same :rhs (buf-get-rhs bufnr mode :lhs))))
+      (describe "buf-map! with {:<buffer> true} in its default-opts"
+        (it "creates current buffer-local mapping by default"
+          (let [bufnr (vim.api.nvim_get_current_buf)]
+            (assert.is_nil (get-rhs :x :lhs))
+            (assert.is_nil (buf-get-rhs 0 :x :lhs))
+            (buf-map!/with-<buffer>=true :x :lhs :rhs)
+            (assert.is_nil (get-rhs :x :lhs))
+            (assert.is_same :rhs (buf-get-rhs 0 :x :lhs))
+            (refresh-buffer)
+            (assert.is_nil (buf-get-rhs 0 :x :lhs))
+            (assert.is_same :rhs (buf-get-rhs bufnr :x :lhs))))
+        (it "can create another buffer-local mapping by overriding option"
+          (let [mode :x
+                bufnr (vim.api.nvim_get_current_buf)]
+            (assert.is_nil (get-rhs mode :lhs))
+            (assert.is_nil (buf-get-rhs 0 mode :lhs))
+            (buf-map!/with-<buffer>=true mode [:buffer bufnr] :lhs :rhs)
+            (assert.is_nil (get-rhs mode :lhs))
+            (assert.is_same :rhs (buf-get-rhs 0 mode :lhs))
+            (refresh-buffer)
+            (assert.is_nil (buf-get-rhs 0 :x :lhs))
+            (assert.is_same :rhs (buf-get-rhs bufnr mode :lhs)))))
+      (describe :omni-map!
+        (it "should map to lhs in any mode"
+          (each [_ mode (ipairs [:n :v :x :s :o :i :l :c :t])]
+            (assert.is_nil (get-rhs mode :lhs)))
+          (omni-map! :lhs :rhs)
+          (each [_ mode (ipairs [:n :v :x :s :o :i :l :c :t])]
+            (assert.is_same :rhs (get-rhs mode :lhs)))))
+      (describe :nmap!
+        (it "can include extra-opts in either first or second arg"
+          (assert.has_no.errors #(nmap! [:nowait] :lhs :rhs))
+          (assert.has_no.errors #(nmap! :lhs [:nowait] :rhs)))
+        (it "maps to current buffer with `<buffer>`"
+          (nmap! [:<buffer>] :lhs :rhs)
+          (assert.is.same :rhs (buf-get-rhs 0 :n :lhs)))
+        (it "maps to specific buffer with `buffer`"
+          (let [bufnr (vim.api.nvim_get_current_buf)]
+            (refresh-buffer)
+            (nmap! [:buffer bufnr] :lhs :rhs)
+            (assert.is_nil (buf-get-rhs 0 :n :lhs))
+            (assert.is.same :rhs (buf-get-rhs bufnr :n :lhs))))
+        (it "set a list which will result in string without callback"
+          (nmap! :lhs &vim (.. :r :h :s))
+          (nmap! :lhs1 &vim (.. (<Cmd> :foobar) :<Esc>))
+          (assert.is.same :rhs (get-rhs :n :lhs))
+          (assert.is.same :<Cmd>foobar<CR><Esc> (get-rhs :n :lhs1)))
+        (it "enables `replace_keycodes` when `expr` is set in `extra-opts`"
+          (nmap! :lhs [:expr] :rhs)
+          (nmap! :lhs1 :rhs {:expr true})
+          (let [opt {:expr true}]
+            (nmap! :lhs2 :rhs opt))
+          (let [{: replace_keycodes} (get-mapargs :n :lhs)]
+            (assert.is.same 1 replace_keycodes))
+          (let [{: replace_keycodes} (get-mapargs :n :lhs1)]
+            (assert.is_nil replace_keycodes))
+          (let [{: replace_keycodes} (get-mapargs :n :lhs2)]
+            (assert.is_nil replace_keycodes)))
+        (it "disables `replace_keycodes` when `literal` is set in `extra-opts`"
+          (nmap! :lhs [:expr :literal] :rhs)
+          (let [{: replace_keycodes} (get-mapargs :n :lhs)]
+            (assert.is_nil replace_keycodes)))))))

--- a/tests/spec/keymap_spec.fnl
+++ b/tests/spec/keymap_spec.fnl
@@ -258,18 +258,18 @@
               (assert.is_same :rhs (buf-get-rhs 0 mode :lhs))
               (refresh-buffer)
               (assert.is_nil (buf-get-rhs 0 mode :lhs))
+              (assert.is_same :rhs (buf-get-rhs bufnr mode :lhs))))
+          (it "can create another buffer-local mapping by overriding option"
+            (let [mode :x
+                  bufnr (vim.api.nvim_get_current_buf)]
+              (refresh-buffer)
+              (assert.is_nil (get-rhs mode :lhs))
+              (assert.is_nil (buf-get-rhs 0 mode :lhs))
+              (buf-map!/with-buffer=0 mode [:buffer bufnr] :lhs :rhs)
+              (assert.is_nil (get-rhs mode :lhs))
+              (assert.is_nil (buf-get-rhs 0 mode :lhs))
+              (refresh-buffer)
               (assert.is_same :rhs (buf-get-rhs bufnr mode :lhs)))))
-        (it "can create another buffer-local mapping by overriding option"
-          (let [mode :x
-                bufnr (vim.api.nvim_get_current_buf)]
-            (refresh-buffer)
-            (assert.is_nil (get-rhs mode :lhs))
-            (assert.is_nil (buf-get-rhs 0 mode :lhs))
-            (buf-map!/with-buffer=0 mode [:buffer bufnr] :lhs :rhs)
-            (assert.is_nil (get-rhs mode :lhs))
-            (assert.is_nil (buf-get-rhs 0 mode :lhs))
-            (refresh-buffer)
-            (assert.is_same :rhs (buf-get-rhs bufnr mode :lhs))))
         (describe "buf-map! with {:<buffer> true} in its default-opts"
           (it "creates current buffer-local mapping by default"
             (let [bufnr (vim.api.nvim_get_current_buf)]


### PR DESCRIPTION
- [x] augroup!
  - [x] Test augroup+ wrapper
- [x] highlight!
  - [x] Test bold-highlight!
  - [x] Test highlight! wrapper with default-namespace
- [x] command!
  - [x] Test buf-command!
- [x] map!
  - [x] Test buf-map!
  - [x] Test remap!
- [x] autocmd!
  - [x] Test buf-autocmd! wrapper
  - [x] Test autocmd! wrapper with default custom augroup id.

Related to #211