### PR TITLE
feat(option): detect infix flag in symbol to append, prepend, ...; deprecate `:foo+`, ..., format and `set+`, ..., macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,14 +220,12 @@ See [laurel.md](./doc/laurel.md) for each macro usage in details.
 
 - [Option](./doc/laurel.md#Option)
 
-| Set (`!`)                 | Append (`+`)              | Prepend (`^`)             | Remove (`-`)              |
-| :------------------------ | :------------------------ | :------------------------ | :------------------------ |
-| [`set!`][set]             | [`set+`][set]             | [`set^`][set]             | [`set-`][set]             |
-| [`setglobal!`][setglobal] | [`setglobal+`][setglobal] | [`setglobal^`][setglobal] | [`setglobal-`][setglobal] |
-| [`setlocal!`][setlocal]   | [`setlocal+`][setlocal]   | [`setlocal^`][setlocal]   | [`setlocal-`][setlocal]   |
-| [`go!`][go]               | [`go+`][go]               | [`go^`][go]               | [`go-`][go]               |
-| [`bo!`][bo]               | --                        | --                        | --                        |
-| [`wo!`][wo]               | --                        | --                        | --                        |
+  - [`set!`](./doc/laurel.md#set)
+  - [`setglobal!`](./doc/laurel.md#setglobal)
+  - [`setlocal!`](./doc/laurel.md#setlocal)
+  - [`go!`](./doc/laurel.md#go)
+  - [`bo!`](./doc/laurel.md#bo)
+  - [`wo!`](./doc/laurel.md#wo)
 
 - [Others](./doc/laurel.md#Others)
   - [`command!`](./doc/laurel.md#command)
@@ -250,9 +248,3 @@ See [CHANGELOG.md](./CHANGELOG.md).
 
 [Fennel]: https://github.com/bakpakin/Fennel
 [hotpot.nvim]: https://github.com/rktjmp/hotpot.nvim
-[set]: ./doc/laurel.md#setsetsetset-
-[setglobal]: ./doc/laurel.md#setglobalsetglobalsetglobalsetglobal-
-[setlocal]: ./doc/laurel.md#setlocalsetlocalsetlocalsetlocal-
-[go]: ./doc/laurel.md#gogogogo-
-[wo]: ./doc/laurel.md#wo
-[bo]: ./doc/laurel.md#bo

--- a/doc/laurel.md
+++ b/doc/laurel.md
@@ -499,36 +499,28 @@ let $PLUGIN_CACHE_HOME = expand('$NVIM_CACHE_HOME/to/plugin/home')
 
 ### Option
 
-| Set (`!`)                 | Append (`+`)              | Prepend (`^`)             | Remove (`-`)              |
-| :------------------------ | :------------------------ | :------------------------ | :------------------------ |
-| [`set!`][set]             | [`set+`][set]             | [`set^`][set]             | [`set-`][set]             |
-| [`setglobal!`][setglobal] | [`setglobal+`][setglobal] | [`setglobal^`][setglobal] | [`setglobal-`][setglobal] |
-| [`setlocal!`][setlocal]   | [`setlocal+`][setlocal]   | [`setlocal^`][setlocal]   | [`setlocal-`][setlocal]   |
-| [`go!`][go]               | [`go+`][go]               | [`go^`][go]               | [`go-`][go]               |
-| [`bo!`][bo]               | undefined                 | undefined                 | undefined                 |
-| [`wo!`][wo]               | undefined                 | undefined                 | undefined                 |
+- [`set!`](#set)
+- [`setglobal!`](#setglobal)
+- [`setlocal!`](#setlocal)
+- [`go!`](#go)
+- [`bo!`](#bo)
+- [`wo!`](#wo)
 
-#### set! / set+ / set^ / set-
+#### set!
 
 Set, append, prepend, or remove, value to the option. Almost equivalent to
 `:set` in Vim script.
 
 ```fennel
-(set! name-?flag ?val)
-(set+ name val)
-(set^ name val)
-(set- name val)
+(set! name ?flag ?val)
 ```
 
-- `name-?flag`: (string) Option name. As long as the option name is
-  bare-string, i.e., neither symbol nor list, this macro has two advantages:
-
-  1. A flag can be appended to the option name. Append `+`, `^`, or `-`, to
-     append, prepend, or remove, values respectively.
-  2. Option name is case-insensitive. You can improve readability a bit with
-     camelCase/PascalCase. Since `:h {option}` is also case-insensitive,
-     `(setlocal! :keywordPrg ":help")` for fennel still makes sense.
-
+- `name`: (string) Option name. As long as the option name is bare-string,
+  option name is case-insensitive; you can improve readability a bit with
+  camelCase/PascalCase. Since `:h {option}` is also case-insensitive,
+  `(setlocal! :keywordPrg ":help")` for fennel still makes sense.
+- `?flag`: (symbol) Omittable flag. Set one of `+`, `^`, or `-` to append,
+  prepend, or remove, value to the option.
 - `?val`: (boolean|number|string|table) New option value. If not provided, the
   value is supposed to be `true` (experimental).
 
@@ -538,8 +530,8 @@ Set, append, prepend, or remove, value to the option. Almost equivalent to
 (set! :completeOpt [:menu :menuone :noselect])
 (set! :listChars {:space :_ :tab: ">~"})
 
-(set! :colorColumn+ :+1)
-(set! :rtp^ [:/path/to/another/dir])
+(set! :colorColumn + :+1)
+(set! :rtp ^ [:/path/to/another/dir])
 
 (local val :yes)
 (set! :signColumn val)
@@ -593,50 +585,31 @@ vim.opt[opt] = false
 Note: There is no plan to support option prefix either `no` or `inv`; instead,
 set `false` or `(not vim.go.foo)` respectively.
 
-Note: This macro has no support for either symbol or list with any flag at
-option name; instead, use `set+`, `set^`, or `set-`, respectively for such
-usage:
-
-```fennel
-;; Invalid usage!
-(let [opt :formatoptions+]
-  (set! opt [:1 :B]))
-;; Use the corresponding macro instead.
-(let [opt :formatoptions]
-  (set+ opt [:1 :B]))
-```
-
-#### setglobal! / setglobal+ / setglobal^ / setglobal-
+#### setglobal!
 
 Set, append, prepend, or remove, global value to the option. Almost equivalent
 to `:setglobal` in Vim script.
 
 ```fennel
-(setglobal! name-?flag ?val)
-(setglobal+ name val)
-(setglobal^ name val)
-(setglobal- name val)
+(setglobal! name ?flag ?val)
 ```
 
-See [`set!`][set] for the details.
+See [`set!`](#set) for the details.
 
-#### setlocal! / setlocal+ / setlocal^ / setlocal-
+#### setlocal!
 
 Set, append, prepend, or remove, local value to the option. Almost equivalent
 to `:setlocal` in Vim script.
 
 ```fennel
-(setlocal! name-?flag ?val)
-(setlocal+ name val)
-(setlocal^ name val)
-(setlocal- name val)
+(setlocal! name ?flag ?val)
 ```
 
-See [`set!`][set] for the details.
+See [`set!`](#set) for the details.
 
-#### go! / go+ / go^ / go-
+#### go!
 
-Aliases of [`setglobal!`][setglobal], [`setglobal+`][setglobal], and so on.
+Alias of [`setglobal!`](#setglobal).
 
 ```fennel
 (go! name value)
@@ -980,12 +953,6 @@ runtime.
    :!git commit -m 'refactor(laurel): update macros'
    ```
 
-[set]: #setsetsetset-
-[setglobal]: #setglobalsetglobalsetglobalsetglobal-
-[setlocal]: #setlocalsetlocalsetlocalsetlocal-
-[go]: #gogogogo-
-[wo]: #wo
-[bo]: #bo
 [-u]: https://neovim.io/doc/user/starting.html#-u
 [Quickfix]: https://neovim.io/doc/user/quickfix.html
 [`:cdo`]: https://neovim.io/doc/user/quickfix.html#%3Acdo

--- a/doc/laurel.md
+++ b/doc/laurel.md
@@ -567,7 +567,7 @@ vim.api.nvim_set_option_value("listchars", "space:_,tab:>~")
 vim.go.number = true
 vim.go.signcolumn = "yes"
 vim.go.formatoptions = "12cB"
-vim.go.completeopt = ["menu", "menuone", "noselect"]
+vim.go.completeopt = {"menu", "menuone", "noselect"}
 vim.go.listchars = {
   space = "_",
   tab = ">~",

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -953,7 +953,7 @@
   ```fennel
   (set+ name val)
   ```"
-  (set! name `+ val))
+  (deprecate :set+ "set! with '+ flag" :v0.7.0 (set! name `+ val)))
 
 (lambda set^ [name val]
   "(Deprecated) Prepend a value to string-style options.
@@ -961,7 +961,7 @@
   ```fennel
   (set^ name val)
   ```"
-  (set! name `^ val))
+  (deprecate :set^ "set! with '^ flag" :v0.7.0 (set! name `^ val)))
 
 (lambda set- [name val]
   "(Deprecated) Remove a value from string-style options.
@@ -969,7 +969,7 @@
   ```fennel
   (set- name val)
   ```"
-  (set! name `- val))
+  (deprecate :set- "set! with '- flag" :v0.7.0 (set! name `- val)))
 
 (lambda setlocal+ [name val]
   "(Deprecated) Append a value to string-style local options.
@@ -977,7 +977,8 @@
   ```fennel
   (setlocal+ name val)
   ```"
-  (setlocal! name `+ val))
+  (deprecate :setlocal+ "setlocal! with '+ flag" :v0.7.0
+             (setlocal! name `+ val)))
 
 (lambda setlocal^ [name val]
   "(Deprecated) Prepend a value to string-style local options.
@@ -985,7 +986,8 @@
   ```fennel
   (setlocal^ name val)
   ```"
-  (setlocal! name `^ val))
+  (deprecate :setlocal+ "setlocal! with '^ flag" :v0.7.0
+             (setlocal! name `^ val)))
 
 (lambda setlocal- [name val]
   "(Deprecated) Remove a value from string-style local options.
@@ -993,7 +995,8 @@
   ```fennel
   (setlocal- name val)
   ```"
-  (setlocal! name `- val))
+  (deprecate :setlocal- "setlocal! with '- flag" :v0.7.0
+             (setlocal! name `- val)))
 
 (lambda setglobal+ [name val]
   "(Deprecated) Append a value to string-style global options.
@@ -1003,7 +1006,8 @@
   ```
   - name: (string) Option name.
   `- val: (string) Additional option value."
-  (setglobal! name `+ val))
+  (deprecate :setglobal+ "setglobal! with '+ flag" :v0.7.0
+             (setglobal! name `+ val)))
 
 (lambda setglobal^ [name val]
   "(Deprecated) Prepend a value from string-style global options.
@@ -1011,7 +1015,8 @@
   ```fennel
   (setglobal^ name val)
   ```"
-  (setglobal! name `^ val))
+  (deprecate :setglobal^ "setglobal! with '^ flag" :v0.7.0
+             (setglobal! name `^ val)))
 
 (lambda setglobal- [name val]
   "(Deprecated) Remove a value from string-style global options.
@@ -1019,7 +1024,8 @@
   ```fennel
   (setglobal- name val)
   ```"
-  (setglobal! name `- val))
+  (deprecate :setglobal- "setglobal! with '- flag" :v0.7.0
+             (setglobal! name `- val)))
 
 ;; Export ///1
 

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -953,7 +953,7 @@
   ```fennel
   (set+ name val)
   ```"
-  (option/modify {} name val "+"))
+  (set! name `+ val))
 
 (lambda set^ [name val]
   "Prepend a value to string-style options.
@@ -961,7 +961,7 @@
   ```fennel
   (set^ name val)
   ```"
-  (option/modify {} name val "^"))
+  (set! name `^ val))
 
 (lambda set- [name val]
   "Remove a value from string-style options.
@@ -969,7 +969,7 @@
   ```fennel
   (set- name val)
   ```"
-  (option/modify {} name val "-"))
+  (set! name `- val))
 
 (lambda setlocal+ [name val]
   "Append a value to string-style local options.
@@ -977,7 +977,7 @@
   ```fennel
   (setlocal+ name val)
   ```"
-  (option/modify {:scope :local} name val "+"))
+  (setlocal! name `+ val))
 
 (lambda setlocal^ [name val]
   "Prepend a value to string-style local options.
@@ -985,7 +985,7 @@
   ```fennel
   (setlocal^ name val)
   ```"
-  (option/modify {:scope :local} name val "^"))
+  (setlocal! name `^ val))
 
 (lambda setlocal- [name val]
   "Remove a value from string-style local options.
@@ -993,7 +993,7 @@
   ```fennel
   (setlocal- name val)
   ```"
-  (option/modify {:scope :local} name val "-"))
+  (setlocal! name `- val))
 
 (lambda setglobal+ [name val]
   "Append a value to string-style global options.
@@ -1002,8 +1002,8 @@
   (setglobal+ name val)
   ```
   - name: (string) Option name.
-  - val: (string) Additional option value."
-  (option/modify {:scope :global} name val "+"))
+  `- val: (string) Additional option value."
+  (setglobal! name `+ val))
 
 (lambda setglobal^ [name val]
   "Prepend a value from string-style global options.
@@ -1011,7 +1011,7 @@
   ```fennel
   (setglobal^ name val)
   ```"
-  (option/modify {:scope :global} name val "^"))
+  (setglobal! name `^ val))
 
 (lambda setglobal- [name val]
   "Remove a value from string-style global options.
@@ -1019,7 +1019,7 @@
   ```fennel
   (setglobal- name val)
   ```"
-  (option/modify {:scope :global} name val "-"))
+  (setglobal! name `- val))
 
 ;; Export ///1
 

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -795,30 +795,6 @@
   ```"
   (option/set {} ...))
 
-(lambda set+ [name val]
-  "Append a value to string-style options.
-  Almost equivalent to `:set {option}+={value}` in Vim script.
-  ```fennel
-  (set+ name val)
-  ```"
-  (option/modify {} name val "+"))
-
-(lambda set^ [name val]
-  "Prepend a value to string-style options.
-  Almost equivalent to `:set {option}^={value}` in Vim script.
-  ```fennel
-  (set^ name val)
-  ```"
-  (option/modify {} name val "^"))
-
-(lambda set- [name val]
-  "Remove a value from string-style options.
-  Almost equivalent to `:set {option}-={value}` in Vim script.
-  ```fennel
-  (set- name val)
-  ```"
-  (option/modify {} name val "-"))
-
 (lambda setlocal! [...]
   "Set local value to the option.
   Almost equivalent to `:setlocal` in Vim script.
@@ -828,30 +804,6 @@
   See `set!` for the details."
   (option/set {:scope :local} ...))
 
-(lambda setlocal+ [name val]
-  "Append a value to string-style local options.
-  Almost equivalent to `:setlocal {option}+={value}` in Vim script.
-  ```fennel
-  (setlocal+ name val)
-  ```"
-  (option/modify {:scope :local} name val "+"))
-
-(lambda setlocal^ [name val]
-  "Prepend a value to string-style local options.
-  Almost equivalent to `:setlocal {option}^={value}` in Vim script.
-  ```fennel
-  (setlocal^ name val)
-  ```"
-  (option/modify {:scope :local} name val "^"))
-
-(lambda setlocal- [name val]
-  "Remove a value from string-style local options.
-  Almost equivalent to `:setlocal {option}-={value}` in Vim script.
-  ```fennel
-  (setlocal- name val)
-  ```"
-  (option/modify {:scope :local} name val "-"))
-
 (lambda setglobal! [...]
   "Set global value to the option.
   Almost equivalent to `:setglobal` in Vim script.
@@ -860,32 +812,6 @@
   ```
   See `set!` for the details."
   (option/set {:scope :global} ...))
-
-(lambda setglobal+ [name val]
-  "Append a value to string-style global options.
-  Almost equivalent to `:setglobal {option}+={value}` in Vim script.
-  ```fennel
-  (setglobal+ name val)
-  ```
-  - name: (string) Option name.
-  - val: (string) Additional option value."
-  (option/modify {:scope :global} name val "+"))
-
-(lambda setglobal^ [name val]
-  "Prepend a value from string-style global options.
-  Almost equivalent to `:setglobal {option}^={value}` in Vim script.
-  ```fennel
-  (setglobal^ name val)
-  ```"
-  (option/modify {:scope :global} name val "^"))
-
-(lambda setglobal- [name val]
-  "Remove a value from string-style global options.
-  Almost equivalent to `:setglobal {option}-={value}` in Vim script.
-  ```fennel
-  (setglobal- name val)
-  ```"
-  (option/modify {:scope :global} name val "-"))
 
 (lambda bo! [name|?id val|name ...]
   "Set a buffer option value.
@@ -1021,6 +947,80 @@
 
 ;; Deprecated ///1
 
+(lambda set+ [name val]
+  "Append a value to string-style options.
+  Almost equivalent to `:set {option}+={value}` in Vim script.
+  ```fennel
+  (set+ name val)
+  ```"
+  (option/modify {} name val "+"))
+
+(lambda set^ [name val]
+  "Prepend a value to string-style options.
+  Almost equivalent to `:set {option}^={value}` in Vim script.
+  ```fennel
+  (set^ name val)
+  ```"
+  (option/modify {} name val "^"))
+
+(lambda set- [name val]
+  "Remove a value from string-style options.
+  Almost equivalent to `:set {option}-={value}` in Vim script.
+  ```fennel
+  (set- name val)
+  ```"
+  (option/modify {} name val "-"))
+
+(lambda setlocal+ [name val]
+  "Append a value to string-style local options.
+  Almost equivalent to `:setlocal {option}+={value}` in Vim script.
+  ```fennel
+  (setlocal+ name val)
+  ```"
+  (option/modify {:scope :local} name val "+"))
+
+(lambda setlocal^ [name val]
+  "Prepend a value to string-style local options.
+  Almost equivalent to `:setlocal {option}^={value}` in Vim script.
+  ```fennel
+  (setlocal^ name val)
+  ```"
+  (option/modify {:scope :local} name val "^"))
+
+(lambda setlocal- [name val]
+  "Remove a value from string-style local options.
+  Almost equivalent to `:setlocal {option}-={value}` in Vim script.
+  ```fennel
+  (setlocal- name val)
+  ```"
+  (option/modify {:scope :local} name val "-"))
+
+(lambda setglobal+ [name val]
+  "Append a value to string-style global options.
+  Almost equivalent to `:setglobal {option}+={value}` in Vim script.
+  ```fennel
+  (setglobal+ name val)
+  ```
+  - name: (string) Option name.
+  - val: (string) Additional option value."
+  (option/modify {:scope :global} name val "+"))
+
+(lambda setglobal^ [name val]
+  "Prepend a value from string-style global options.
+  Almost equivalent to `:setglobal {option}^={value}` in Vim script.
+  ```fennel
+  (setglobal^ name val)
+  ```"
+  (option/modify {:scope :global} name val "^"))
+
+(lambda setglobal- [name val]
+  "Remove a value from string-style global options.
+  Almost equivalent to `:setglobal {option}-={value}` in Vim script.
+  ```fennel
+  (setglobal- name val)
+  ```"
+  (option/modify {:scope :global} name val "-"))
+
 ;; Export ///1
 
 {: map!
@@ -1031,21 +1031,9 @@
  : autocmd!
  :au! autocmd!
  : set!
- : set+
- : set^
- : set-
  : setlocal!
- : setlocal+
- : setlocal^
- : setlocal-
  : setglobal!
- : setglobal+
- : setglobal^
- : setglobal-
  :go! setglobal!
- :go+ setglobal+
- :go^ setglobal^
- :go- setglobal-
  : bo!
  : wo!
  : g!
@@ -1057,6 +1045,18 @@
  : command!
  : feedkeys!
  : highlight!
- :hi! highlight!}
+ :hi! highlight!
+ : set+
+ : set^
+ : set-
+ : setlocal+
+ : setlocal^
+ : setlocal-
+ : setglobal+
+ : setglobal^
+ : setglobal-
+ :go+ setglobal+
+ :go^ setglobal^
+ :go- setglobal-}
 
 ;; vim:fdm=marker:foldmarker=///,""""

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -781,7 +781,7 @@
   "Set value to the option.
   Almost equivalent to `:set` in Vim script.
   ```fennel
-  (set! name ?'flag ?val)
+  (set! name ?flag ?val)
   ```
   @param name string Option name.
     As long as the option name is a bare string, i.e., neither symbol nor list,
@@ -789,7 +789,7 @@
     improve readability a bit with camelCase/PascalCase. Since `:h {option}`
     is also case-insensitive, `(setlocal! :keywordPrg \":help\")` for fennel
     still makes sense.
-  @param ?'flag quoted-symbol One of \"'+\", \"'-\", \"'^\" is available.
+  @param ?flag symbol One of `+`, `-`, or `^` is available.
   @param ?val boolean|number|string|table New option value.
     If not provided, the value is supposed to be `true` (experimental).
     This macro is expanding to `(vim.api.nvim_set_option_value name val)`;

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -757,7 +757,7 @@
         name (if ?flag (: name-?flag :match "[a-zA-Z]+") name-?flag)]
     (values name ?flag)))
 
-(fn option/set [scope ...]
+(fn option/set-with-scope [scope ...]
   (assert-compile (table? scope) "Expected kv-table" scope)
   (let [supported-flags [`+ `- `^ `! `& `<]
         [name ?flag val] ;
@@ -801,7 +801,7 @@
   (let [opt :formatOptions]
     (set! opt + [:1 :B]))
   ```"
-  (option/set {} ...))
+  (option/set-with-scope {} ...))
 
 (lambda setlocal! [...]
   "Set local value to the option.
@@ -810,7 +810,7 @@
   (setlocal! name-?flag ?val)
   ```
   See `set!` for the details."
-  (option/set {:scope :local} ...))
+  (option/set-with-scope {:scope :local} ...))
 
 (lambda setglobal! [...]
   "Set global value to the option.
@@ -819,7 +819,7 @@
   (setglobal! name-?flag ?val)
   ```
   See `set!` for the details."
-  (option/set {:scope :global} ...))
+  (option/set-with-scope {:scope :global} ...))
 
 (lambda bo! [name|?id val|name ...]
   "Set a buffer option value.

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -769,7 +769,7 @@
 
 ;; Export ///2
 
-(lambda set! [name-?flag ?val]
+(lambda set! [...]
   "Set value to the option.
   Almost equivalent to `:set` in Vim script.
   ```fennel
@@ -781,7 +781,7 @@
     improve readability a bit with camelCase/PascalCase. Since `:h {option}`
     is also case-insensitive, `(setlocal! :keywordPrg \":help\")` for fennel
     still makes sense.
-  @param ?'flag quoted-symbol One of \"'+\", \"'-\", \"^\" is available.
+  @param ?'flag quoted-symbol One of \"'+\", \"'-\", \"'^\" is available.
   @param ?val boolean|number|string|table New option value.
     If not provided, the value is supposed to be `true` (experimental).
     This macro is expanding to `(vim.api.nvim_set_option_value name val)`;
@@ -789,18 +789,11 @@
     this macro is expanding to `(tset vim.opt name val)` instead.
   Note: There is no plan to support option prefix either `no` or `inv`;
   instead, set `false` or `(not vim.go.foo)` respectively.
-  Note: This macro has no support for either symbol or list with any flag at
-  option name; instead, use `set+`, `set^`, or `set-`, respectively for such
-  usage:
   ```fennel
-  ;; Invalid usage!
-  (let [opt :formatOptions+]
-    (set! opt [:1 :B]))
-  ;; Use the corresponding macro instead.
   (let [opt :formatOptions]
-    (set+ opt [:1 :B]))
+    (set! opt + [:1 :B]))
   ```"
-  (option/set {} name-?flag ?val))
+  (option/set {} ...))
 
 (lambda set+ [name val]
   "Append a value to string-style options.
@@ -826,14 +819,14 @@
   ```"
   (option/modify {} name val "-"))
 
-(lambda setlocal! [name-?flag ?val]
+(lambda setlocal! [...]
   "Set local value to the option.
   Almost equivalent to `:setlocal` in Vim script.
   ```fennel
   (setlocal! name-?flag ?val)
   ```
   See `set!` for the details."
-  (option/set {:scope :local} name-?flag ?val))
+  (option/set {:scope :local} ...))
 
 (lambda setlocal+ [name val]
   "Append a value to string-style local options.
@@ -859,14 +852,14 @@
   ```"
   (option/modify {:scope :local} name val "-"))
 
-(lambda setglobal! [name-?flag ?val]
+(lambda setglobal! [...]
   "Set global value to the option.
   Almost equivalent to `:setglobal` in Vim script.
   ```fennel
   (setglobal! name-?flag ?val)
   ```
   See `set!` for the details."
-  (option/set {:scope :global} name-?flag ?val))
+  (option/set {:scope :global} ...))
 
 (lambda setglobal+ [name val]
   "Append a value to string-style global options.

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -762,16 +762,15 @@
   "Set value to the option.
   Almost equivalent to `:set` in Vim script.
   ```fennel
-  (set! name-?flag ?val)
+  (set! name ?'flag ?val)
   ```
-  @param name-?flag string Option name.
+  @param name string Option name.
     As long as the option name is a bare string, i.e., neither symbol nor list,
-    this macro has two advantages:
-    1. A flag can be appended to the option name. Append `+`, `^`, or `-`,
-       to append, prepend, or remove values, respectively.
-    2. Option name is case-insensitive. You can improve readability a bit with
-       camelCase/PascalCase. Since `:h {option}` is also case-insensitive,
-       `(setlocal! :keywordPrg \":help\")` for fennel still makes sense.
+    this macro has an advantage: option name is case-insensitive. You can
+    improve readability a bit with camelCase/PascalCase. Since `:h {option}`
+    is also case-insensitive, `(setlocal! :keywordPrg \":help\")` for fennel
+    still makes sense.
+  @param ?'flag quoted-symbol One of \"'+\", \"'-\", \"^\" is available.
   @param ?val boolean|number|string|table New option value.
     If not provided, the value is supposed to be `true` (experimental).
     This macro is expanding to `(vim.api.nvim_set_option_value name val)`;

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -749,11 +749,22 @@
         name (if ?flag (: name-?flag :match "[a-zA-Z]+") name-?flag)]
     (values name ?flag)))
 
-(lambda option/set [scope name-?flag ?val]
-  (let [[name ?flag] (if (str? name-?flag)
-                         [(option/extract-flag name-?flag)]
-                         [name-?flag nil])
-        val (if (nil? ?val) true ?val)]
+(fn option/set [scope ...]
+  (assert-compile (table? scope) "Expected kv-table" scope)
+  (let [[name ?flag val] ;
+        (match ...
+          (name nil)
+          [name nil true]
+          (where (name flag ?val)
+                 (and (sym? flag)
+                      (contains? ["+" "-" "^" "!" "&" "<"] (->str flag))))
+          [name (->str flag) ?val]
+          ;; TODO: Remove flag-extraction on v0.7.0.
+          (name-?flag val nil)
+          (if (str? name-?flag)
+              (let [(name ?flag) (option/extract-flag name-?flag)]
+                [name ?flag val])
+              [name-?flag nil val]))]
     (option/modify scope name val ?flag)))
 
 ;; Export ///2

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -751,13 +751,13 @@
 
 (fn option/set [scope ...]
   (assert-compile (table? scope) "Expected kv-table" scope)
-  (let [[name ?flag val] ;
+  (let [supported-flags ["+" "-" "^" "!" "&" "<"]
+        [name ?flag val] ;
         (match ...
           (name nil)
           [name nil true]
           (where (name flag ?val)
-                 (and (sym? flag)
-                      (contains? ["+" "-" "^" "!" "&" "<"] (->str flag))))
+                 (and (sym? flag) (contains? supported-flags (->str flag))))
           [name (->str flag) ?val]
           ;; TODO: Remove flag-extraction on v0.7.0.
           (name-?flag val nil)

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -747,11 +747,11 @@
 (lambda option/extract-flag [name-?flag]
   (let [?flag (: name-?flag :match "[^a-zA-Z]")
         name (if ?flag (: name-?flag :match "[a-zA-Z]+") name-?flag)]
-    [name ?flag]))
+    (values name ?flag)))
 
 (lambda option/set [scope name-?flag ?val]
   (let [[name ?flag] (if (str? name-?flag)
-                         (option/extract-flag name-?flag)
+                         [(option/extract-flag name-?flag)]
                          [name-?flag nil])
         val (if (nil? ?val) true ?val)]
     (option/modify scope name val ?flag)))

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -948,7 +948,7 @@
 ;; Deprecated ///1
 
 (lambda set+ [name val]
-  "Append a value to string-style options.
+  "(Deprecated) Append a value to string-style options.
   Almost equivalent to `:set {option}+={value}` in Vim script.
   ```fennel
   (set+ name val)
@@ -956,7 +956,7 @@
   (set! name `+ val))
 
 (lambda set^ [name val]
-  "Prepend a value to string-style options.
+  "(Deprecated) Prepend a value to string-style options.
   Almost equivalent to `:set {option}^={value}` in Vim script.
   ```fennel
   (set^ name val)
@@ -964,7 +964,7 @@
   (set! name `^ val))
 
 (lambda set- [name val]
-  "Remove a value from string-style options.
+  "(Deprecated) Remove a value from string-style options.
   Almost equivalent to `:set {option}-={value}` in Vim script.
   ```fennel
   (set- name val)
@@ -972,7 +972,7 @@
   (set! name `- val))
 
 (lambda setlocal+ [name val]
-  "Append a value to string-style local options.
+  "(Deprecated) Append a value to string-style local options.
   Almost equivalent to `:setlocal {option}+={value}` in Vim script.
   ```fennel
   (setlocal+ name val)
@@ -980,7 +980,7 @@
   (setlocal! name `+ val))
 
 (lambda setlocal^ [name val]
-  "Prepend a value to string-style local options.
+  "(Deprecated) Prepend a value to string-style local options.
   Almost equivalent to `:setlocal {option}^={value}` in Vim script.
   ```fennel
   (setlocal^ name val)
@@ -988,7 +988,7 @@
   (setlocal! name `^ val))
 
 (lambda setlocal- [name val]
-  "Remove a value from string-style local options.
+  "(Deprecated) Remove a value from string-style local options.
   Almost equivalent to `:setlocal {option}-={value}` in Vim script.
   ```fennel
   (setlocal- name val)
@@ -996,7 +996,7 @@
   (setlocal! name `- val))
 
 (lambda setglobal+ [name val]
-  "Append a value to string-style global options.
+  "(Deprecated) Append a value to string-style global options.
   Almost equivalent to `:setglobal {option}+={value}` in Vim script.
   ```fennel
   (setglobal+ name val)
@@ -1006,7 +1006,7 @@
   (setglobal! name `+ val))
 
 (lambda setglobal^ [name val]
-  "Prepend a value from string-style global options.
+  "(Deprecated) Prepend a value from string-style global options.
   Almost equivalent to `:setglobal {option}^={value}` in Vim script.
   ```fennel
   (setglobal^ name val)
@@ -1014,7 +1014,7 @@
   (setglobal! name `^ val))
 
 (lambda setglobal- [name val]
-  "Remove a value from string-style global options.
+  "(Deprecated) Remove a value from string-style global options.
   Almost equivalent to `:setglobal {option}-={value}` in Vim script.
   ```fennel
   (setglobal- name val)

--- a/tests/spec/_wrapper_macros.fnl
+++ b/tests/spec/_wrapper_macros.fnl
@@ -1,9 +1,18 @@
-(local {: augroup! : map!} (require :nvim-laurel.macros))
+(local {: augroup! : set! : map!} (require :nvim-laurel.macros))
 
 (fn augroup+ [name ...]
   (augroup! name
     {:clear false}
     ...))
+
+(fn set+ [name ...]
+  (set! name `+ ...))
+
+(fn set- [name ...]
+  (set! name `- ...))
+
+(fn set^ [name ...]
+  (set! name `^ ...))
 
 (fn nmap! [...]
   (map! :n ...))
@@ -11,4 +20,4 @@
 (fn omni-map! [...]
   (map! ["" "!" :l :t] ...))
 
-{: augroup+ : nmap! : omni-map!}
+{: augroup+ : set+ : set- : set^ : nmap! : omni-map!}

--- a/tests/spec/option_spec.fnl
+++ b/tests/spec/option_spec.fnl
@@ -1,12 +1,7 @@
 (import-macros {: describe : it} :_busted_macros)
-(import-macros {: set!
-                : set+
-                : set^
-                : set-
-                : setglobal!
-                : setlocal!
-                : bo!
-                : wo!} :nvim-laurel.macros)
+(import-macros {: set+ : set- : set^} :_wrapper_macros)
+(import-macros {: set! : setglobal! : setlocal! : bo! : wo!}
+               :nvim-laurel.macros)
 
 (macro get-o [name]
   `(-> (. vim.opt ,name) (: :get)))

--- a/tests/spec/option_spec.fnl
+++ b/tests/spec/option_spec.fnl
@@ -130,37 +130,37 @@
       (vim.cmd "set path+=/foo,/bar,/baz")
       (let [vals (get-o-lo-go :path)]
         (reset-context)
-        (set! :path+ [:/foo :/bar :/baz])
+        (set! :path + [:/foo :/bar :/baz])
         (assert.is_same vals (get-o-lo-go :path))))
     (it "can prepend option value of sequence"
       (vim.cmd "set path^=/foo,/bar,/baz")
       (let [vals (get-o-lo-go :path)]
         (reset-context)
-        (set! :path^ [:/foo :/bar :/baz])
+        (set! :path ^ [:/foo :/bar :/baz])
         (assert.is_same vals (get-o-lo-go :path))))
     (it "can remove option value of sequence"
       (vim.cmd "set path-=/tmp,/var")
       (let [vals (get-o-lo-go :path)]
         (reset-context)
-        (set! :path- [:/tmp :/var])
+        (set! :path - [:/tmp :/var])
         (assert.is_same vals (get-o-lo-go :path))))
     (it "can append option value of kv-table"
       (: vim.opt.listchars :append {:lead :a :trail :b :extends :c})
       (let [vals (get-o-lo-go :listchars)]
         (reset-context)
-        (set! :listchars+ {:lead :a :trail :b :extends :c})
+        (set! :listchars + {:lead :a :trail :b :extends :c})
         (assert.is_same vals (get-o-lo-go :listchars))))
     (it "can prepend option value of kv-table"
       (: vim.opt.listchars :prepend {:lead :a :trail :b :extends :c})
       (let [vals (get-o-lo-go :listchars)]
         (reset-context)
-        (set! :listchars^ {:lead :a :trail :b :extends :c})
+        (set! :listchars ^ {:lead :a :trail :b :extends :c})
         (assert.is_same vals (get-o-lo-go :listchars))))
     (it "can remove option value of kv-table"
       (: vim.opt.listchars :remove [:eol :tab])
       (let [vals (get-o-lo-go :listchars)]
         (reset-context)
-        (set! :listchars- [:eol :tab])
+        (set! :listchars - [:eol :tab])
         (assert.is_same vals (get-o-lo-go :listchars))))
     (describe "with no value"
       (it "updates option value to `true`"
@@ -229,37 +229,37 @@
       (: vim.opt_local.path :append [:/foo :/bar :/baz])
       (let [vals (get-o-lo-go :path)]
         (reset-context)
-        (setlocal! :path+ [:/foo :/bar :/baz])
+        (setlocal! :path + [:/foo :/bar :/baz])
         (assert.is_same vals (get-o-lo-go :path))))
     (it "can prepend option value of sequence"
       (: vim.opt_local.path :prepend [:/foo :/bar :/baz])
       (let [vals (get-o-lo-go :path)]
         (reset-context)
-        (setlocal! :path^ [:/foo :/bar :/baz])
+        (setlocal! :path ^ [:/foo :/bar :/baz])
         (assert.is_same vals (get-o-lo-go :path))))
     (it "can remove option value of sequence"
       (: vim.opt_local.path :remove [:/tmp :/var])
       (let [vals (get-o-lo-go :path)]
         (reset-context)
-        (setlocal! :path- [:/tmp :/var])
+        (setlocal! :path - [:/tmp :/var])
         (assert.is_same vals (get-o-lo-go :path))))
     (it "can append option value of kv-table"
       (: vim.opt_local.listchars :append {:lead :a :trail :b :extends :c})
       (let [vals (get-o-lo-go :listchars)]
         (reset-context)
-        (setlocal! :listchars+ {:lead :a :trail :b :extends :c})
+        (setlocal! :listchars + {:lead :a :trail :b :extends :c})
         (assert.is_same vals (get-o-lo-go :listchars))))
     (it "can prepend option value of kv-table"
       (: vim.opt_local.listchars :prepend {:lead :a :trail :b :extends :c})
       (let [vals (get-o-lo-go :listchars)]
         (reset-context)
-        (setlocal! :listchars^ {:lead :a :trail :b :extends :c})
+        (setlocal! :listchars ^ {:lead :a :trail :b :extends :c})
         (assert.is_same vals (get-o-lo-go :listchars))))
     (it "can remove option value of kv-table"
       (: vim.opt_local.listchars :remove [:eol :tab])
       (let [vals (get-o-lo-go :listchars)]
         (reset-context)
-        (setlocal! :listchars- [:eol :tab])
+        (setlocal! :listchars - [:eol :tab])
         (assert.is_same vals (get-o-lo-go :listchars))))
     (describe "with no value"
       (it "updates option value to `true`"
@@ -276,16 +276,16 @@
     (describe "for &l:formatoptions"
       (it "can append flags in sequence"
         ;; Note: In truth, the formatoptions flag order doesn't matter.
-        (setlocal! :formatOptions+ [:a :r :B])
+        (setlocal! :formatOptions + [:a :r :B])
         (assert.is_same {:1 true :2 true :b true :a true :r true :B true}
                         (get-lo :formatoptions)))
       (it "can prepend flags in sequence"
         ;; Note: In truth, the formatoptions flag order doesn't matter.
-        (setlocal! :formatOptions^ [:a :r :B])
+        (setlocal! :formatOptions ^ [:a :r :B])
         (assert.is_same {:1 true :2 true :b true :a true :r true :B true}
                         (get-lo :formatoptions)))
       (it "can remove flags in sequence"
-        (setlocal! :formatOptions- [:b :2])
+        (setlocal! :formatOptions - [:b :2])
         (assert.is_same {:1 true} (get-lo :formatoptions)))
       (it "can set symbol in sequence"
         (let [val :r]
@@ -346,51 +346,51 @@
       (: vim.opt_global.path :append [:/foo :/bar :/baz])
       (let [vals (get-o-lo-go :path)]
         (reset-context)
-        (setglobal! :path+ [:/foo :/bar :/baz])
+        (setglobal! :path + [:/foo :/bar :/baz])
         (assert.is_same vals (get-o-lo-go :path))))
     (it "can prepend option value of sequence"
       (: vim.opt_global.path :prepend [:/foo :/bar :/baz])
       (let [vals (get-o-lo-go :path)]
         (reset-context)
-        (setglobal! :path^ [:/foo :/bar :/baz])
+        (setglobal! :path ^ [:/foo :/bar :/baz])
         (assert.is_same vals (get-o-lo-go :path))))
     (it "can remove option value of sequence"
       (: vim.opt_global.path :remove [:/tmp :/var])
       (let [vals (get-o-lo-go :path)]
         (reset-context)
-        (setglobal! :path- [:/tmp :/var])
+        (setglobal! :path - [:/tmp :/var])
         (assert.is_same vals (get-o-lo-go :path))))
     (it "can append option value of kv-table"
       (: vim.opt_global.listchars :append {:lead :a :trail :b :extends :c})
       (let [vals (get-o-lo-go :listchars)]
         (reset-context)
-        (setglobal! :listchars+ {:lead :a :trail :b :extends :c})
+        (setglobal! :listchars + {:lead :a :trail :b :extends :c})
         (assert.is_same vals (get-o-lo-go :listchars))))
     (it "can prepend option value of kv-table"
       (: vim.opt_global.listchars :prepend {:lead :a :trail :b :extends :c})
       (let [vals (get-o-lo-go :listchars)]
         (reset-context)
-        (setglobal! :listchars^ {:lead :a :trail :b :extends :c})
+        (setglobal! :listchars ^ {:lead :a :trail :b :extends :c})
         (assert.is_same vals (get-o-lo-go :listchars))))
     (it "can remove option value of kv-table"
       (: vim.opt_global.listchars :remove [:eol :tab])
       (let [vals (get-o-lo-go :listchars)]
         (reset-context)
-        (setglobal! :listchars- [:eol :tab])
+        (setglobal! :listchars - [:eol :tab])
         (assert.is_same vals (get-o-lo-go :listchars))))
     (describe "for &l:shortmess"
       (it "can append flags in sequence"
         ;; Note: In truth, the shortmess flag order doesn't matter.
-        (setglobal! :shortMess+ [:m :n :r])
+        (setglobal! :shortMess + [:m :n :r])
         (assert.is_same {:f true :i true :w true :m true :n true :r true}
                         (get-lo :shortmess)))
       (it "can prepend flags in sequence"
         ;; Note: In truth, the shortmess flag order doesn't matter.
-        (setglobal! :shortMess^ [:m :n :r])
+        (setglobal! :shortMess ^ [:m :n :r])
         (assert.is_same {:f true :i true :w true :m true :n true :r true}
                         (get-lo :shortmess)))
       (it "can remove flags in sequence"
-        (setglobal! :shortMess- [:i :f])
+        (setglobal! :shortMess - [:i :f])
         (assert.is_same {:w true} (get-lo :shortmess))))
     (describe "with no value"
       (it "updates option value to `true`"

--- a/tests/spec/option_spec.fnl
+++ b/tests/spec/option_spec.fnl
@@ -1,7 +1,13 @@
 (import-macros {: describe : it} :_busted_macros)
 (import-macros {: set+ : set- : set^} :_wrapper_macros)
-(import-macros {: set! : setglobal! : setlocal! : bo! : wo!}
-               :nvim-laurel.macros)
+(import-macros {: set!
+                : setglobal!
+                : setlocal!
+                : bo!
+                : wo!
+                :set+ deprecated/set+
+                :set- deprecated/set-
+                :set^ deprecated/set^} :nvim-laurel.macros)
 
 (macro get-o [name]
   `(-> (. vim.opt ,name) (: :get)))
@@ -639,4 +645,56 @@
           (let [expected-vals (get-o-lo-go name)]
             (reset-context)
             (set- name assigned-val)
+            (assert.is_same expected-vals (get-o-lo-go name)))))))
+  (describe "(deprecated, v0.7.0 will not support it)"
+    (describe :set+
+      (it "appends option value of sequence"
+        (let [name :path
+              assigned-val [:/foo :/bar :/baz]]
+          (-> (. vim.opt name) (: :append assigned-val))
+          (let [expected-vals (get-o-lo-go name)]
+            (reset-context)
+            (deprecated/set+ name assigned-val)
+            (assert.is_same expected-vals (get-o-lo-go name)))))
+      (it "appends option value of kv-table"
+        (let [name :listchars
+              assigned-val {:lead :a :trail :b :extends :c}]
+          (-> (. vim.opt name) (: :append assigned-val))
+          (let [expected-vals (get-o-lo-go name)]
+            (reset-context)
+            (deprecated/set+ name assigned-val)
+            (assert.is_same expected-vals (get-o-lo-go name))))))
+    (describe :set^
+      (it "prepends option value of sequence"
+        (let [name :path
+              assigned-val [:/foo :/bar :/baz]]
+          (-> (. vim.opt name) (: :prepend assigned-val))
+          (let [expected-vals (get-o-lo-go name)]
+            (reset-context)
+            (deprecated/set^ name assigned-val)
+            (assert.is_same expected-vals (get-o-lo-go name)))))
+      (it "prepends option value of kv-table"
+        (let [name :listchars
+              assigned-val {:lead :a :trail :b :extends :c}]
+          (-> (. vim.opt name) (: :prepend assigned-val))
+          (let [expected-vals (get-o-lo-go name)]
+            (reset-context)
+            (deprecated/set^ name assigned-val)
+            (assert.is_same expected-vals (get-o-lo-go name))))))
+    (describe :set-
+      (it "removes option value of sequence"
+        (let [name :path
+              assigned-val [:/tmp :/var]]
+          (-> (. vim.opt name) (: :remove assigned-val))
+          (let [expected-vals (get-o-lo-go name)]
+            (reset-context)
+            (deprecated/set- name assigned-val)
+            (assert.is_same expected-vals (get-o-lo-go name)))))
+      (it "removes option value of kv-table"
+        (let [name :listchars
+              assigned-val {:lead :a :trail :b :extends :c}]
+          (-> (. vim.opt name) (: :remove assigned-val))
+          (let [expected-vals (get-o-lo-go name)]
+            (reset-context)
+            (deprecated/set- name assigned-val)
             (assert.is_same expected-vals (get-o-lo-go name))))))))

--- a/tests/spec/option_spec.fnl
+++ b/tests/spec/option_spec.fnl
@@ -593,54 +593,55 @@
           (vim.cmd.new)
           (wo! win :foldlevel (return-val))
           (assert.is_same new-val (. vim.wo win :foldlevel))))))
-  (describe :set+
-    (it "appends option value of sequence"
-      (let [name :path
-            assigned-val [:/foo :/bar :/baz]]
-        (-> (. vim.opt name) (: :append assigned-val))
-        (let [expected-vals (get-o-lo-go name)]
-          (reset-context)
-          (set+ name assigned-val)
-          (assert.is_same expected-vals (get-o-lo-go name)))))
-    (it "appends option value of kv-table"
-      (let [name :listchars
-            assigned-val {:lead :a :trail :b :extends :c}]
-        (-> (. vim.opt name) (: :append assigned-val))
-        (let [expected-vals (get-o-lo-go name)]
-          (reset-context)
-          (set+ name assigned-val)
-          (assert.is_same expected-vals (get-o-lo-go name))))))
-  (describe :set^
-    (it "prepends option value of sequence"
-      (let [name :path
-            assigned-val [:/foo :/bar :/baz]]
-        (-> (. vim.opt name) (: :prepend assigned-val))
-        (let [expected-vals (get-o-lo-go name)]
-          (reset-context)
-          (set^ name assigned-val)
-          (assert.is_same expected-vals (get-o-lo-go name)))))
-    (it "prepends option value of kv-table"
-      (let [name :listchars
-            assigned-val {:lead :a :trail :b :extends :c}]
-        (-> (. vim.opt name) (: :prepend assigned-val))
-        (let [expected-vals (get-o-lo-go name)]
-          (reset-context)
-          (set^ name assigned-val)
-          (assert.is_same expected-vals (get-o-lo-go name))))))
-  (describe :set-
-    (it "removes option value of sequence"
-      (let [name :path
-            assigned-val [:/tmp :/var]]
-        (-> (. vim.opt name) (: :remove assigned-val))
-        (let [expected-vals (get-o-lo-go name)]
-          (reset-context)
-          (set- name assigned-val)
-          (assert.is_same expected-vals (get-o-lo-go name)))))
-    (it "removes option value of kv-table"
-      (let [name :listchars
-            assigned-val {:lead :a :trail :b :extends :c}]
-        (-> (. vim.opt name) (: :remove assigned-val))
-        (let [expected-vals (get-o-lo-go name)]
-          (reset-context)
-          (set- name assigned-val)
-          (assert.is_same expected-vals (get-o-lo-go name)))))))
+  (describe "(wrapper)"
+    (describe :set+
+      (it "appends option value of sequence"
+        (let [name :path
+              assigned-val [:/foo :/bar :/baz]]
+          (-> (. vim.opt name) (: :append assigned-val))
+          (let [expected-vals (get-o-lo-go name)]
+            (reset-context)
+            (set+ name assigned-val)
+            (assert.is_same expected-vals (get-o-lo-go name)))))
+      (it "appends option value of kv-table"
+        (let [name :listchars
+              assigned-val {:lead :a :trail :b :extends :c}]
+          (-> (. vim.opt name) (: :append assigned-val))
+          (let [expected-vals (get-o-lo-go name)]
+            (reset-context)
+            (set+ name assigned-val)
+            (assert.is_same expected-vals (get-o-lo-go name))))))
+    (describe :set^
+      (it "prepends option value of sequence"
+        (let [name :path
+              assigned-val [:/foo :/bar :/baz]]
+          (-> (. vim.opt name) (: :prepend assigned-val))
+          (let [expected-vals (get-o-lo-go name)]
+            (reset-context)
+            (set^ name assigned-val)
+            (assert.is_same expected-vals (get-o-lo-go name)))))
+      (it "prepends option value of kv-table"
+        (let [name :listchars
+              assigned-val {:lead :a :trail :b :extends :c}]
+          (-> (. vim.opt name) (: :prepend assigned-val))
+          (let [expected-vals (get-o-lo-go name)]
+            (reset-context)
+            (set^ name assigned-val)
+            (assert.is_same expected-vals (get-o-lo-go name))))))
+    (describe :set-
+      (it "removes option value of sequence"
+        (let [name :path
+              assigned-val [:/tmp :/var]]
+          (-> (. vim.opt name) (: :remove assigned-val))
+          (let [expected-vals (get-o-lo-go name)]
+            (reset-context)
+            (set- name assigned-val)
+            (assert.is_same expected-vals (get-o-lo-go name)))))
+      (it "removes option value of kv-table"
+        (let [name :listchars
+              assigned-val {:lead :a :trail :b :extends :c}]
+          (-> (. vim.opt name) (: :remove assigned-val))
+          (let [expected-vals (get-o-lo-go name)]
+            (reset-context)
+            (set- name assigned-val)
+            (assert.is_same expected-vals (get-o-lo-go name))))))))


### PR DESCRIPTION
- [x] Update vimdoc.
- [x] Update specs.