### PR TITLE
test(spec): update spec for `opt_global` with `nil` assigned on nvim nightly

### DIFF
--- a/tests/spec/option_spec.fnl
+++ b/tests/spec/option_spec.fnl
@@ -322,12 +322,15 @@
         (reset-context)
         (setglobal! :listchars {:eol :a :tab :abc :space :a})
         (assert.is_same vals (get-o-lo-go :listchars))))
-    (it "can update some option value with nil"
-      (set vim.opt_global.foldlevel nil)
-      (let [vals (get-o-lo-go :foldlevel)]
-        (reset-context)
-        (setglobal! :foldlevel nil)
-        (assert.is_same vals (get-o-lo-go :foldlevel))))
+    (if (= 1 (vim.fn.has :nvim-0.10.0-dev))
+        (it "throws an error with nil assigned"
+          (assert.error #(set vim.opt_global.foldlevel nil)))
+        (it "can update some option value with nil"
+          (set vim.opt_global.foldlevel nil)
+          (let [vals (get-o-lo-go :foldlevel)]
+            (reset-context)
+            (setglobal! :foldlevel nil)
+            (assert.is_same vals (get-o-lo-go :foldlevel)))))
     (it "can update some option value with symbol"
       (let [new-val 2]
         (set vim.opt_global.foldlevel new-val)


### PR DESCRIPTION
On nvim nightly (roughly 0.10.0-dev), an attempt to assign `nil` to `vim.opt_global` throws the error: "vim/_options.lua:0: Cannot unset global option value"
This PR updates the spec for [the current nightly version](https://github.com/neovim/neovim/commit/848fc8ede84b9cfc4e651e0e3b449060a8a8d70c), or later, of nvim.
I don't identify the actual version that has broken the spec.