### PR TITLE
Revert "ci: update actions"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,18 +12,17 @@ jobs:
     runs-on: ubuntu-22.04
     if: ${{ github.ref == 'refs/heads/main' && github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: Generate vimdoc
-        uses: kdheepak/panvimdoc@v4.0.0
+        uses: kdheepak/panvimdoc@main
         with:
           vimdoc: laurel
           pandoc: doc/laurel.md
           version: "Neovim >= 0.8.0"
           demojify: true
           treesitter: true
-          dedupsubheadings: false # Add heading to subheading anchor links to ensure that subheadings are unique
       - name: PR new vimdoc
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v4
         with:
           branch: create-pull-request--branches--main--vimdoc
           title: "docs(vimdoc): auto-generate"
@@ -39,7 +38,7 @@ jobs:
     needs: vimdoc
     runs-on: ubuntu-22.04
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: google-github-actions/release-please-action@v3
         with:
           release-type: simple
           package-name: nvim-laurel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,10 @@ jobs:
     env:
       LUAROCKS_HOME: /home/runner/.local/.luarocks
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - run: date +%Y%W > weekly
       - name: Restore test dependencies in Luarocks
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         id: cache-luarocks
         with:
           path: |


### PR DESCRIPTION
Reverts aileot/nvim-laurel#238

release-please-action@v4 no longer supports GitHub action inputs, so the workflow is invalid.

Closes #239
