### PR TITLE
test(busted): remove `(require :busted)`

### DIFF
--- a/tests/spec/_busted_macros.fnl
+++ b/tests/spec/_busted_macros.fnl
@@ -20,16 +20,12 @@
       `#(do
           ,...)))
 
-(lambda busted [name]
-  `(. (require :busted) ,name))
-
 (lambda inject-fn [name ...]
   "Construct busted wrapper.
  @param name string busted method name
  @param ... list a function, or any number of list to be wrapped into a function."
-  (assert (< 0 (select "#" ...)) (: "expected one or more args for %s" :format
-                                    name))
-  `(,(busted name) ,(->fn ...)))
+  (assert (< 0 (select "#" ...)) "expected one or more args")
+  `(,name ,(->fn ...)))
 
 (lambda inject-desc-fn [name desc ...]
   "Construct busted wrapper.
@@ -37,31 +33,32 @@
   @param desc string spec description
   @param ... list a function, or any number of list to be wrapped into a function"
   (when-not (varg? desc)
-    (assert (< 0 (select "#" ...))
-            (: "expected one or more args for %s(\"%s\")" :format name desc)))
-  `(,(busted name) ,desc ,(->fn ...)))
+    (assert (< 0 (select "#" ...)) "expected one or more args"))
+  `(,name ,desc ,(->fn ...)))
 
-(local after_each (partial inject-fn :after_each))
-(local before_each (partial inject-fn :before_each))
-(local describe (partial inject-desc-fn :describe))
-(local expose (partial inject-desc-fn :expose))
-(local insulate (partial inject-desc-fn :insulate))
-(local it (partial inject-desc-fn :it))
-(local setup (partial inject-fn :setup))
-(local teardown (partial inject-fn :teardown))
+(local after_each* (partial inject-fn `after_each))
+(local before_each* (partial inject-fn `before_each))
+(local describe* (partial inject-desc-fn `describe))
+(local expose* (partial inject-desc-fn `expose))
+(local insulate* (partial inject-desc-fn `insulate))
+(local it* (partial inject-desc-fn `it))
+(local setup* (partial inject-fn `setup))
+(local teardown* (partial inject-fn `teardown))
 
-;; (fn pending [desc ...]
-;;   ;; WIP
-;;   (if (= :string (type desc))
-;;       (inject-desc-fn :pending desc ...)
-;;       (inject-fn :pending desc ...)))
+(fn pending* [desc ...]
+  ;; WIP
+  (if (= :string (type desc))
+      (inject-desc-fn `pending desc ...)
+      (inject-fn `pending desc ...)))
 
-{: after_each
- : before_each
- : describe
- : expose
- : insulate
- : it
- ;; : pending
- : setup
- : teardown}
+{: after_each*
+ : before_each*
+ :after-each after_each*
+ :before-each before_each*
+ : describe*
+ : expose*
+ : insulate*
+ : it*
+ ;; :pending pending*
+ : setup*
+ : teardown*}

--- a/tests/spec/autocmd_spec.fnl
+++ b/tests/spec/autocmd_spec.fnl
@@ -1,4 +1,9 @@
-(import-macros {: describe : it} :_busted_macros)
+(import-macros {: setup*
+                : teardown*
+                : before-each
+                : after-each
+                : describe*
+                : it*} :_busted_macros)
 (import-macros {: augroup! : au! : autocmd!} :nvim-laurel.macros)
 (import-macros {: my-autocmd!
                 : augroup+
@@ -43,32 +48,32 @@
 
 ;; Note: `(vim.cmd "normal! i")` does not trigger event `InsertEnter` in the
 ;; nvim nightly v0.10; use `vim.api.nvim_exec_autocmds` instead.
-(describe :autocmd
-  (setup (fn []
-           (let [nvim-builtin-augroups [:nvim_cmdwin
-                                        :nvim_terminal
-                                        :nvim_swapfile]]
-             (each [_ group (ipairs nvim-builtin-augroups)]
-               (augroup! group)))
-           (vim.cmd "function g:Test() abort\nendfunction")))
-  (teardown (fn []
-              (vim.cmd "delfunction g:Test")))
-  (before_each (fn []
+(describe* :autocmd
+  (setup* (fn []
+            (let [nvim-builtin-augroups [:nvim_cmdwin
+                                         :nvim_terminal
+                                         :nvim_swapfile]]
+              (each [_ group (ipairs nvim-builtin-augroups)]
+                (augroup! group)))
+            (vim.cmd "function g:Test() abort\nendfunction")))
+  (teardown* (fn []
+               (vim.cmd "delfunction g:Test")))
+  (before-each (fn []
                  (when another-augroup-name
                    (del-augroup-by-name another-augroup-name)
                    (set another-augroup-name nil))
                  (set default-augroup-id (augroup! default-augroup))
                  (let [aus (get-autocmds {})]
                    (assert.is_nil (next aus)))))
-  (after_each (fn []
+  (after-each (fn []
                 (pcall del-autocmd au-id1)
                 (pcall del-autocmd au-id2)
                 (pcall del-autocmd au-id3)))
-  (describe :augroup!
-    (it "returns augroup id without autocmds insides"
+  (describe* :augroup!
+    (it* "returns augroup id without autocmds insides"
       (let [id (augroup! default-augroup)]
         (assert.has_no_errors #(del-augroup-by-id id))))
-    (it "can create augroup with `au!` macro and sequence without `au!` macro mixed"
+    (it* "can create augroup with `au!` macro and sequence without `au!` macro mixed"
       (assert.has_no_errors #(augroup! default-augroup
                                [default-event default-callback]
                                (au! :FileType [:foo :bar] #:foobar)
@@ -76,9 +81,9 @@
                                (au! :FileType [:foo :bar] #:foobar)
                                [default-event default-callback]
                                (au! :FileType [:foo :bar] #:foobar)))))
-  (describe :au!/autocmd!
-    (describe "nested autocmds"
-      (it "callback arg value at `group` is `nil` when parent group is `nil`."
+  (describe* :au!/autocmd!
+    (describe* "nested autocmds"
+      (it* "callback arg value at `group` is `nil` when parent group is `nil`."
         (let [desc "nil group to InsertEnter"
               s (spy.new)]
           (set au-id1
@@ -98,7 +103,7 @@
             (assert.is_same 1 (length aus)))
           (let [aus (get-autocmds {:event [:BufWritePre]})]
             (assert.is_same 1 (length aus)))))
-      (it "callback arg value at `group` is same as the parent group id."
+      (it* "callback arg value at `group` is same as the parent group id."
         (let [s (spy.new)]
           (set au-id1
                (au! default-augroup [:InsertEnter]
@@ -117,7 +122,7 @@
             (assert.is_same {:InsertEnter true :BufWritePre true}
                             {au1.event true au2.event true})
             (assert.is_same 2 (length aus)))))
-      (it "callback arg value at `group` is same as the parent group id even inside `augroup!` macro."
+      (it* "callback arg value at `group` is same as the parent group id even inside `augroup!` macro."
         (let [s (spy.new)]
           (set another-augroup-name :foobar)
           (augroup! another-augroup-name
@@ -171,7 +176,7 @@
                              au3.event true
                              au4.event true})
             (assert.is_same 4 (length aus)))))
-      (it "callback arg value at `group` is same as the parent group id even inside `augroup!` macro with 'buffer' key assigned."
+      (it* "callback arg value at `group` is same as the parent group id even inside `augroup!` macro with 'buffer' key assigned."
         (let [s (spy.new)]
           (augroup! default-augroup
             (au! [:InsertEnter] [:buffer 0 :desc "spawned autocmd"]
@@ -191,51 +196,51 @@
             (assert.is_same {:InsertEnter true :BufWritePre true}
                             {au1.event true au2.event true})
             (assert.is_same 2 (length aus))))))
-    (it "should set callback via macro"
+    (it* "should set callback via macro"
       (let [desc "macro callback"]
         (autocmd! default-augroup default-event [:pat] [:desc desc]
                   (macro-callback))
         (let [au (get-first-autocmd {:pattern :pat})]
           (assert.is_same desc au.desc))))
-    (it "should set callback function in symbol"
+    (it* "should set callback function in symbol"
       (autocmd! default-augroup default-event [:pat] default-callback)
       (assert.is_same default-callback
                       (. (get-first-autocmd {:pattern :pat}) :callback)))
-    (it "should set callback function in multi-symbol"
+    (it* "should set callback function in multi-symbol"
       (let [desc :multi.sym]
         (autocmd! default-augroup default-event [:pat] default.multi.sym
                   {: desc})
         ;; FIXME: In vusted, callback is unexpectedly set to a string
-        ;; "<vim function: default.multi.sym>"; it must be the same as
+        ;; "<vim function: default.multi.sym>"; it* must be the same as
         ;; `default.multi.sym`.
         (assert.is_same desc (. (get-first-autocmd {:pattern :pat}) :desc))))
-    (it "should set callback function in list"
+    (it* "should set callback function in list"
       (let [desc :list]
         (autocmd! default-augroup default-event [:pat]
                   (default-callback :foo :bar) {: desc})
         (let [au (get-first-autocmd {:pattern :pat})]
           (assert.is_same desc au.desc))))
-    (it "should set vim.fn.Test in string \"Test\""
+    (it* "should set vim.fn.Test in string \"Test\""
       (autocmd! default-augroup default-event [:pat] vim.fn.Test)
       (let [au (get-first-autocmd {:pattern :pat})]
         (assert.is_same "<vim function: Test>" au.callback)))
-    (it "set #(vim.fn.Test) to callback without modification"
+    (it* "set #(vim.fn.Test) to callback without modification"
       (autocmd! default-augroup default-event [:pat] #(vim.fn.Test))
       (let [au (get-first-autocmd {:pattern :pat})]
         (assert.is_not_same "<vim function: Test>" au.callback)))
-    (it "can add an autocmd to an existing augroup"
+    (it* "can add an autocmd to an existing augroup"
       (autocmd! default-augroup default-event [:pat1 :pat2] default-callback)
       (let [[au1] (get-autocmds {:group default-augroup})]
         (assert.is_same default-callback au1.callback)))
-    (it "can add autocmd with no patterns for macro"
+    (it* "can add autocmd with no patterns for macro"
       (assert.has_no.errors #(autocmd! default-augroup default-event
                                        default-callback)))
-    (it "sets vim.fn.Test to callback in string"
+    (it* "sets vim.fn.Test to callback in string"
       (assert.has_no.errors #(autocmd! default-augroup default-event
                                        vim.fn.Test))
       (let [[autocmd] (get-autocmds {:group default-augroup})]
         (assert.is.same "<vim function: Test>" autocmd.callback)))
-    (it "creates buffer-local autocmd with `buffer` key"
+    (it* "creates buffer-local autocmd with `buffer` key"
       (let [buffer (vim.api.nvim_get_current_buf)
             au1 (au! default-augroup default-event [:buffer buffer]
                      default-callback)]
@@ -248,9 +253,9 @@
               (get-autocmds {:buffer (vim.api.nvim_get_current_buf)})]
           (assert.is.same au1 autocmd1.id)
           (assert.is.same au2 autocmd2.id))))
-    (it "can define autocmd without any augroup"
+    (it* "can define autocmd without any augroup"
       (set au-id1 (au! nil default-event default-callback)))
-    (it "gives lowest priority to `pattern` as (< raw seq tbl)"
+    (it* "gives lowest priority to `pattern` as (< raw seq tbl)"
       (let [seq-pat :seq-pat
             tbl-pat :tbl-pat]
         (au! default-augroup default-event [:raw-seq-pat] default-callback)
@@ -262,78 +267,78 @@
           (assert.is.same seq-pat au.pattern))
         (let [au (get-first-autocmd {:pattern tbl-pat})]
           (assert.is.same tbl-pat au.pattern))))
-    (describe "detects 2 args:"
-      (it "sequence pattern and string callback"
+    (describe* "detects 2 args:"
+      (it* "sequence pattern and string callback"
         (autocmd! default-augroup default-event [:pat] :callback))
-      (it "sequence pattern and function callback"
+      (it* "sequence pattern and function callback"
         (autocmd! default-augroup default-event [:pat] #:callback))
-      (it "sequence pattern and symbol callback"
+      (it* "sequence pattern and symbol callback"
         (let [cb :callback]
           (autocmd! default-augroup default-event [:pat] cb)))
-      (it "extra-opts and string callback"
+      (it* "extra-opts and string callback"
         (autocmd! default-augroup default-event [:pat] :callback))
-      (it "extra-opts and function callback"
+      (it* "extra-opts and function callback"
         (autocmd! default-augroup default-event [:pat] #:callback))
-      (it "extra-opts and symbol callback"
+      (it* "extra-opts and symbol callback"
         (let [cb :callback]
           (autocmd! default-augroup default-event [:pat] cb)))
-      (it "string callback and api-opts in table"
+      (it* "string callback and api-opts in table"
         (autocmd! default-augroup default-event :callback {:nested true}))
-      (it "string callback and api-opts in symbol"
+      (it* "string callback and api-opts in symbol"
         (let [opts {:nested true}]
           (autocmd! default-augroup default-event :callback opts)))
-      (it "function callback and api-opts in table"
+      (it* "function callback and api-opts in table"
         (autocmd! default-augroup default-event #:callback {:nested true}))
-      (it "function callback and api-opts in symbol"
+      (it* "function callback and api-opts in symbol"
         (let [opts {:nested true}]
           (autocmd! default-augroup default-event #:callback opts)))
-      (it "symbol callback and api-opts in table"
+      (it* "symbol callback and api-opts in table"
         (let [cb :callback]
           (autocmd! default-augroup default-event cb {:nested true})))
-      (it "symbol callback and api-opts in symbol"
+      (it* "symbol callback and api-opts in symbol"
         (let [cb :callback
               opts {:nested true}]
           (autocmd! default-augroup default-event cb opts))))
-    (describe :<Cmd>pattern
-      (it "symbol will be set to 'command'"
+    (describe* :<Cmd>pattern
+      (it* "symbol will be set to 'command'"
         (au! default-augroup default-event [:pat1] <default>-command)
         (let [au (get-first-autocmd {:pattern :pat1})]
           (assert.is_same <default>-command au.command)))
-      (it "list will be set to 'command'"
+      (it* "list will be set to 'command'"
         (au! default-augroup default-event [:pat1] (<default>-str-callback))
         (let [au (get-first-autocmd {:pattern :pat1})]
           (assert.is_same (<default>-str-callback) au.command))))
-    (describe "with symbol &vim"
-      (it "should set symbol to `command`"
+    (describe* "with symbol &vim"
+      (it* "should set symbol to `command`"
         (au! default-augroup default-event [:pat1] &vim default-command)
         (let [[autocmd1] (get-autocmds {:pattern :pat1})]
           (assert.is_same default-command autocmd1.command)))
-      (it "should set list to `command`"
+      (it* "should set list to `command`"
         (autocmd! default-augroup default-event [:pat] &vim (macro-command))
         (let [au (get-first-autocmd {:pattern :pat})]
           (assert.is_same :macro-command au.command))))
-    (describe "(wrapper)"
-      (describe "with `&default-opts`,"
-        (describe "imported macro"
-          (describe :augroup+
-            (it "gets an existing augroup id"
+    (describe* "(wrapper)"
+      (describe* "with `&default-opts`,"
+        (describe* "imported macro"
+          (describe* :augroup+
+            (it* "gets an existing augroup id"
               (let [id (augroup! default-augroup)]
                 (assert.is_same id (augroup+ default-augroup))))
-            (it "can add autocmds to an existing augroup within `augroup+`"
+            (it* "can add autocmds to an existing augroup within `augroup+`"
               (augroup+ default-augroup
                 (au! default-event [:pat1 :pat2] default-callback))
               (let [[autocmd] (get-autocmds {:group default-augroup})]
                 (assert.is_same default-callback autocmd.callback))))
-          (it "can create autocmd in predefined augroup in global-scope"
+          (it* "can create autocmd in predefined augroup in global-scope"
             (set au-id1 (my-autocmd! [:FileType] [:foo] default-callback))
             (let [[au &as aus] (get-autocmds {:group _G.my-augroup-id})]
               (assert.is_same 1 (length aus))
               (assert.is_same :foo au.pattern))))
-        (describe "local macro"
-          (describe "carefully binding variables without gensym in order to get conflicted with existing variable"
+        (describe* "local macro"
+          (describe* "carefully binding variables without gensym in order to get conflicted with existing variable"
             ;; Note: Another spec, carelessly bound to undefined variable,
             ;; throws error too earlier in nvim >= 0.10.
-            (it "can define buffer-local autocmd wrapper"
+            (it* "can define buffer-local autocmd wrapper"
               (var foo false)
               (let [id (augroup! default-augroup)]
                 (macro buf-au! [...]
@@ -352,7 +357,7 @@
                     (assert.is_same 1 (length aus))
                     (assert.is_same :InsertEnter au1.event)
                     (assert.is_same buffer au1.buffer)))))
-            (it "can spawn a buffer-local augroup"
+            (it* "can spawn a buffer-local augroup"
               (let [local-group-prefix :local
                     bufnr (vim.api.nvim_get_current_buf)]
                 (augroup! default-augroup
@@ -367,7 +372,7 @@
                 (let [[au1 &as aus] (get-autocmds {:group another-augroup-name})]
                   (assert.is_same 1 (length aus))
                   (assert.is_same :InsertEnter au1.event)))))
-          (it "can spawn buffer-local autocmd from a spawned buffer-local augroup"
+          (it* "can spawn buffer-local autocmd from a spawned buffer-local augroup"
             (let [local-group-prefix :local]
               (augroup! default-augroup
                 (au! [:FileType]
@@ -400,8 +405,8 @@
                   (assert.is_same {:InsertEnter true :BufWritePre true}
                                   {au1.event true au2.event true})
                   (assert.is_same 2 (length aus)))))))
-        (describe "wrapper function at runtime"
-          (it "usually causes errors because compiled into unexpected output."
+        (describe* "wrapper function at runtime"
+          (it* "usually causes errors because compiled into unexpected output."
             (autocmd! default-augroup [:FileType]
                       (fn [au]
                         (let [buf-local-augroup-name (: "buf-local-aug-%d"

--- a/tests/spec/command_spec.fnl
+++ b/tests/spec/command_spec.fnl
@@ -1,4 +1,4 @@
-(import-macros {: describe : it} :_busted_macros)
+(import-macros {: before-each : describe* : it*} :_busted_macros)
 (import-macros {: command!} :nvim-laurel.macros)
 (import-macros {: buf-command!/as-api-alias} :_wrapper_macros)
 
@@ -27,20 +27,20 @@
   (-> (vim.api.nvim_buf_get_commands bufnr {:builtin false})
       (. name)))
 
-(describe :command!
-  (before_each (fn []
+(describe* :command!
+  (before-each (fn []
                  (pcall vim.api.nvim_del_user_command :Foo)
                  (pcall vim.api.nvim_buf_del_user_command 0 :Foo)
                  (assert.is_nil (get-command :Foo))))
-  (it "defines user command"
+  (it* "defines user command"
     (assert.is_nil (get-command :Foo))
     (command! :Foo :Bar)
     (assert.is_not_nil (get-command :Foo)))
-  (it "defines local user command for current buffer with `<buffer>` attr"
+  (it* "defines local user command for current buffer with `<buffer>` attr"
     (assert.is_nil (get-buf-command 0 :Foo))
     (command! [:<buffer>] :Foo :Bar)
     (assert.is_not_nil (get-buf-command 0 :Foo)))
-  (it "defines local user command with buffer number"
+  (it* "defines local user command with buffer number"
     (let [bufnr (vim.api.nvim_get_current_buf)]
       (assert.is_nil (get-buf-command bufnr :Foo))
       (vim.cmd.new)
@@ -48,44 +48,50 @@
       (command! :Foo [:buffer bufnr] :Bar)
       (assert.is_not_nil (get-buf-command bufnr :Foo))
       (assert.has_no_error #(vim.api.nvim_buf_del_user_command bufnr :Foo))))
-  (it "which sets callback vim.fn.Test will not be overridden by `desc` key"
+  (it* "which sets callback vim.fn.Test will not be overridden by `desc` key"
     ;; Note: The reason is probably vim.fn.Test is not a Lua function but
     ;; a Vim one.
     (let [desc :Test]
       (command! :Foo vim.fn.Test)
       (assert.is_same "" (get-command-definition :Foo))
       (assert.is_not_same desc (get-command-definition :Foo))))
-  (it "set command in macro with no args"
+  (it* "set command in macro with no args"
     (command! :Foo (macro-command))
     (assert.is_same :macro-command (get-command-definition :Foo)))
-  (it "set command in macro with some args"
+  (it* "set command in macro with some args"
     (command! :Foo (macro-command :foo :bar))
     (assert.is_same :macro-command (get-command-definition :Foo)))
-  (describe :extra-opts
-    (it "can be either first arg or second arg"
+  (describe* :extra-opts
+    (it* "can be either first arg or second arg"
       (assert.has_no_error #(command! [:bang] :Foo :Bar))
       (assert.has_no_error #(command! :Foo [:bang] :Bar))))
-  (describe :api-opts
-    (it "gives priority api-opts over extra-opts"
+  (describe* :api-opts
+    (it* "gives priority api-opts over extra-opts"
       (command! :Foo [:bar :bang] :FooBar)
       (assert.is_true (-> (get-command :Foo) (. :bang)))
       (assert.is_true (-> (get-command :Foo) (. :bar)))
-      (command! :Bar [:bar :bang] :FooBar {:bar false})
+      (command! :Bar [:bar :bang]
+        :FooBar
+        {:bar false})
       (assert.is_false (-> (get-command :Bar) (. :bar)))
       (let [tbl-opts {:bar false}
             fn-opts #{:bang false}]
-        (command! :Baz [:bar :bang] :FooBar tbl-opts)
-        (command! :Qux [:bar :bang] :FooBar (fn-opts))
+        (command! :Baz [:bar :bang]
+          :FooBar
+          tbl-opts)
+        (command! :Qux [:bar :bang]
+          :FooBar
+          (fn-opts))
         (let [cmd-baz (get-command :Baz)
               cmd-qux (get-command :Qux)]
           (assert.is_false cmd-baz.bar)
           (assert.is_true cmd-baz.bang)
           (assert.is_true cmd-qux.bar)
           (assert.is_false cmd-qux.bang)))))
-  (describe "(wrapper)"
-    (describe :buf-command!
-      (describe "as an alias of vim.api.nvim_buf_create_user_command()"
-        (it "can be defined as a macro"
+  (describe* "(wrapper)"
+    (describe* :buf-command!
+      (describe* "as an alias of vim.api.nvim_buf_create_user_command()"
+        (it* "can be defined as a macro"
           (vim.cmd.new)
           (vim.cmd.only)
           (let [bufnr (vim.api.nvim_get_current_buf)]
@@ -93,8 +99,8 @@
             (assert.has_no_error #(buf-command!/as-api-alias bufnr :Foo :Bar))
             (assert.is_not_nil (get-buf-command bufnr :Foo))
             (assert.has_no_error #(vim.api.nvim_buf_del_user_command bufnr :Foo)))))
-      (describe "which creates command for current buffer by default"
-        (it "can be defined as a macro"
+      (describe* "which creates command for current buffer by default"
+        (it* "can be defined as a macro"
           (vim.cmd.new)
           (vim.cmd.only)
           (let [bufnr (vim.api.nvim_get_current_buf)]
@@ -103,7 +109,7 @@
                                                                           :Bar))
             (assert.is_not_nil (get-buf-command bufnr :Foo))
             (assert.has_no_error #(vim.api.nvim_buf_del_user_command bufnr :Foo))))
-        (it "can overwrite target buffer"
+        (it* "can overwrite target buffer"
           (let [buf1 (vim.api.nvim_get_current_buf)]
             (vim.cmd.new)
             (vim.cmd.only)

--- a/tests/spec/highlight_spec.fnl
+++ b/tests/spec/highlight_spec.fnl
@@ -1,4 +1,4 @@
-(import-macros {: describe : it} :_busted_macros)
+(import-macros {: before-each : describe* : it*} :_busted_macros)
 (import-macros {: highlight!} :nvim-laurel.macros)
 (import-macros {: bold-highlight!} :_wrapper_macros)
 
@@ -47,8 +47,8 @@
       (accumulate [decimal 0 m (hex:gmatch "%x")]
         (+ (* 16 decimal) (. hex-map m))))))
 
-(describe :highlight!
-  (it "can define hl-group with color name"
+(describe* :highlight!
+  (it* "can define hl-group with color name"
     (highlight! :Foo {:fg :Red :bg :Black :bold true})
     (highlight! :Bar {:ctermfg :Red :ctermbg :Black :bold true})
     (highlight! :Baz {:fg :Red
@@ -56,38 +56,38 @@
                       :bold true
                       :ctermfg :Red
                       :ctermbg :Black}))
-  (it "can define hl-group with 256-color code"
+  (it* "can define hl-group with 256-color code"
     (highlight! :Foo {:ctermfg 0 :ctermbg 255 :bold true})
     (highlight! :Bar {:fg 0 :bg 255 :bold true :ctermfg 0 :ctermbg 255})
     (assert.is_same {:foreground 0 :background 255 :bold true}
                     (get-hl-of-256-color :Foo))
     (assert.is_same {:foreground 0 :background 255 :bold true}
                     (get-hl-of-256-color :Bar)))
-  (it "for gui can define hl-group with color code"
+  (it* "for gui can define hl-group with color code"
     (highlight! :FooBar {:fg "#000000" :bg "#FFFFFF" :bold true})
     (assert.is_same {:foreground (hex->decimal "#000000")
                      :background (hex->decimal "#FFFFFF")
                      :bold true}
                     (get-hl-of-rgb-color :FooBar)))
-  (it "can link to another hl-group"
+  (it* "can link to another hl-group"
     (highlight! :Foo {:ctermfg 0 :ctermbg 255 :bold true})
     (highlight! :Bar {:link :Foo})
     (assert.is_same {:foreground 0 :background 255 :bold true}
                     (get-hl-of-256-color :Bar)))
-  (describe "with its value in bare-kv-table"
-    (it "can set fg/bg in cterm table instead of ctermfg/ctermbg"
+  (describe* "with its value in bare-kv-table"
+    (it* "can set fg/bg in cterm table instead of ctermfg/ctermbg"
       (highlight! :FooBar {:cterm {:fg 0 :bg 255 :bold true}})
       (assert.is_same {:foreground 0 :background 255 :bold true}
                       (get-hl-of-256-color :FooBar))))
-  (describe "whose kv-table value in symbol"
-    (it "can define hl-group with color name"
+  (describe* "whose kv-table value in symbol"
+    (it* "can define hl-group with color name"
       (let [foo {:fg :Red :bg :Black :bold true}
             bar {:ctermfg :Red :ctermbg :Black :bold true}
             baz {:fg :Red :bg :Black :bold true :ctermfg :Red :ctermbg :Black}]
         (highlight! :Foo foo)
         (highlight! :Bar bar)
         (highlight! :Baz baz)))
-    (it "can define hl-group with 256-color code"
+    (it* "can define hl-group with 256-color code"
       (let [foo {:ctermfg 0 :ctermbg 255 :bold true}
             bar {:fg 0 :bg 255 :bold true :ctermfg 0 :ctermbg 255}]
         (highlight! :Foo foo)
@@ -96,35 +96,35 @@
                         (get-hl-of-256-color :Foo))
         (assert.is_same {:foreground 0 :background 255 :bold true}
                         (get-hl-of-256-color :Bar))))
-    (it "for gui can define hl-group with color code"
+    (it* "for gui can define hl-group with color code"
       (let [foobar {:fg "#000000" :bg "#FFFFFF" :bold true}]
         (highlight! :FooBar foobar)
         (assert.is_same {:foreground (hex->decimal "#000000")
                          :background (hex->decimal "#FFFFFF")
                          :bold true}
                         (get-hl-of-rgb-color :FooBar))))
-    (it "can link to another hl-group"
+    (it* "can link to another hl-group"
       (let [foo {:ctermfg 0 :ctermbg 255 :bold true}
             bar {:link :Foo}]
         (highlight! :Foo foo)
         (highlight! :Bar bar))
       (assert.is_same {:foreground 0 :background 255 :bold true}
                       (get-hl-of-256-color :Bar)))
-    (describe "with its value in bare-kv-table"
-      (it "cannot set fg/bg in cterm table instead of ctermfg/ctermbg"
+    (describe* "with its value in bare-kv-table"
+      (it* "cannot set fg/bg in cterm table instead of ctermfg/ctermbg"
         (let [foobar {:cterm {:fg 0 :bg 255 :bold true}}]
           ;; Note: fg/bg in `cterm` table is invalid; instead, use
           ;; ctermfg/ctermbg respectively.
           (assert.has_error #(highlight! :FooBar foobar))))))
-  (describe "whose kv-table value in list"
-    (it "can define hl-group with color name"
+  (describe* "whose kv-table value in list"
+    (it* "can define hl-group with color name"
       (let [foo #{:fg :Red :bg :Black :bold true}
             bar #{:ctermfg :Red :ctermbg :Black :bold true}
             baz #{:fg :Red :bg :Black :bold true :ctermfg :Red :ctermbg :Black}]
         (highlight! :Foo (foo))
         (highlight! :Bar (bar))
         (highlight! :Baz (baz))))
-    (it "can define hl-group with 256-color code"
+    (it* "can define hl-group with 256-color code"
       (let [foo #{:ctermfg 0 :ctermbg 255 :bold true}
             bar #{:fg 0 :bg 255 :bold true :ctermfg 0 :ctermbg 255}]
         (highlight! :Foo (foo))
@@ -133,52 +133,52 @@
                         (get-hl-of-256-color :Foo))
         (assert.is_same {:foreground 0 :background 255 :bold true}
                         (get-hl-of-256-color :Bar))))
-    (it "for gui can define hl-group with color code"
+    (it* "for gui can define hl-group with color code"
       (let [foobar #{:fg "#000000" :bg "#FFFFFF" :bold true}]
         (highlight! :FooBar (foobar))
         (assert.is_same {:foreground (hex->decimal "#000000")
                          :background (hex->decimal "#FFFFFF")
                          :bold true}
                         (get-hl-of-rgb-color :FooBar))))
-    (it "can link to another hl-group"
+    (it* "can link to another hl-group"
       (let [foo #{:ctermfg 0 :ctermbg 255 :bold true}
             bar #{:link :Foo}]
         (highlight! :Foo (foo))
         (highlight! :Bar (bar)))
       (assert.is_same {:foreground 0 :background 255 :bold true}
                       (get-hl-of-256-color :Bar)))
-    (describe "with its value in bare-kv-table"
-      (it "cannot set fg/bg in cterm table instead of ctermfg/ctermbg"
+    (describe* "with its value in bare-kv-table"
+      (it* "cannot set fg/bg in cterm table instead of ctermfg/ctermbg"
         (let [foobar #{:cterm {:fg 0 :bg 255 :bold true}}]
           ;; Note: fg/bg in `cterm` table is invalid; instead, use
           ;; ctermfg/ctermbg respectively.
           (assert.has_error #(highlight! :FooBar (foobar)))))))
-  (describe "(wrapper)"
+  (describe* "(wrapper)"
     ;; TODO: Also test them in the versions < 0.9.0, where `nvim_get_hl` does
     ;; not exist.
     (when vim.api.nvim_get_hl
-      (describe "with predefined-namespace-id"
-        (before_each (fn []
+      (describe* "with predefined-namespace-id"
+        (before-each (fn []
                        (vim.api.nvim_set_hl predefined-namespace-id
                                             test-hl-name {})
                        (assert.is_same (vim.empty_dict)
                                        (get-hl predefined-namespace-id
                                                {:name test-hl-name}))))
-        (it "can be embedded in a macro"
+        (it* "can be embedded in a macro"
           (module-hi! test-hl-name {:ctermfg 0 :ctermbg 255})
           (assert.is_not_same (vim.empty_dict)
                               (get-hl predefined-namespace-id
                                       {:name test-hl-name}))
           (assert.is_same {:ctermfg 0 :ctermbg 255}
                           (get-hl predefined-namespace-id {:name test-hl-name}))))
-      (describe "defined in another file"
-        (describe "with &default-opts"
-          (describe "{: bold true}"
-            (it "creates bold highlight by default"
+      (describe* "defined in another file"
+        (describe* "with &default-opts"
+          (describe* "{: bold true}"
+            (it* "creates bold highlight by default"
               (bold-highlight! test-hl-name {:ctermfg 0 :ctermbg 255})
               (assert.is_true (-> (get-hl 0 {:name test-hl-name})
                                   (. :bold))))
-            (it "can remove bold option"
+            (it* "can remove bold option"
               (bold-highlight! test-hl-name
                                {:ctermfg 0 :ctermbg 255 :bold false})
               (assert.is_falsy (-> (get-hl 0 {:name test-hl-name})

--- a/tests/spec/keymap_spec.fnl
+++ b/tests/spec/keymap_spec.fnl
@@ -1,4 +1,5 @@
-(import-macros {: describe : it} :_busted_macros)
+(import-macros {: setup* : teardown* : before-each : describe* : it*}
+               :_busted_macros)
 (import-macros {: nmap!
                 : omni-map!
                 : remap!
@@ -55,32 +56,32 @@
 (lambda buf-get-callback [bufnr mode lhs]
   (?. (buf-get-mapargs bufnr mode lhs) :callback))
 
-(describe :macros.keymap
-  (setup (fn []
-           (vim.cmd "function g:Test()\nendfunction")))
-  (teardown (fn []
-              (vim.cmd "delfunction g:Test")))
-  (before_each (fn []
+(describe* :macros.keymap
+  (setup* (fn []
+            (vim.cmd "function g:Test()\nendfunction")))
+  (teardown* (fn []
+               (vim.cmd "delfunction g:Test")))
+  (before-each (fn []
                  (let [all-modes ["" "!" :l :t]]
                    (each [_ mode (ipairs all-modes)]
                      (pcall vim.api.nvim_del_keymap mode :lhs)
                      (assert.is_nil (get-rhs mode :lhs))))))
-  (describe :map!
-    (it "should set callback function in symbol"
+  (describe* :map!
+    (it* "should set callback function in symbol"
       (map! :n :lhs default-callback)
       (assert.is_same default-callback (get-callback :n :lhs)))
-    (it "should set callback function in multi-symbol"
+    (it* "should set callback function in multi-symbol"
       (let [desc :multi.sym]
         (map! :n :lhs default.multi.sym.callback {: desc})
         (assert.is_same default.multi.sym.callback (get-callback :n :lhs))))
-    (it "should set callback function in list"
+    (it* "should set callback function in list"
       (let [desc :list]
         (map! :n :lhs (default-callback :foo :bar) {: desc})
         (assert.is_same desc (. (get-mapargs :n :lhs) :desc))))
-    (it "should set callback function in string for vim.fn.Test"
+    (it* "should set callback function in string for vim.fn.Test"
       (map! :n :lhs vim.fn.Test)
       (assert.is_same vim.fn.Test (get-callback :n :lhs)))
-    (it "maps non-recursively by default"
+    (it* "maps non-recursively by default"
       (let [mode :n
             modes [:n :o :t]]
         (map! mode :lhs :rhs)
@@ -90,7 +91,7 @@
         (each [_ m (ipairs modes)]
           (let [{: noremap} (get-mapargs m :lhs)]
             (assert.is.same 1 noremap)))))
-    (it "is also available to recursive mappings"
+    (it* "is also available to recursive mappings"
       (let [mode :n]
         (map! :o [:remap] :lhs :rhs)
         (map! mode [:remap] :lhs :rhs)
@@ -98,7 +99,7 @@
           (assert.is.same 0 noremap))
         (let [{: noremap} (get-mapargs mode :lhs)]
           (assert.is.same 0 noremap))))
-    (it "gives priority to `api-opts`"
+    (it* "gives priority to `api-opts`"
       (let [mode :n
             modes [:i :c :t]
             api-opts {:noremap true}]
@@ -112,60 +113,60 @@
         (each [_ m (ipairs modes)]
           (let [{: noremap} (get-mapargs m :lhs)]
             (assert.is.same 1 noremap)))))
-    (it "should set callback via macro"
+    (it* "should set callback via macro"
       (map! :n :lhs (macro-callback))
       (assert.is_not_nil (get-callback :n :lhs)))
-    (it "set command in macro with no args"
+    (it* "set command in macro with no args"
       (map! :n :lhs &vim (macro-command))
       (assert.is_same :macro-command (get-rhs :n :lhs)))
-    (it "set command in macro with some args"
+    (it* "set command in macro with some args"
       (map! :n :lhs &vim (macro-command :foo :bar))
       (assert.is_same :macro-command (get-rhs :n :lhs)))
-    (it "maps multiple mode mappings with a sequence at once"
+    (it* "maps multiple mode mappings with a sequence at once"
       (let [modes [:n :c :t]]
         (map! modes :lhs :rhs)
         (each [_ mode (ipairs modes)]
           (assert.is.same :rhs (get-rhs mode :lhs)))))
-    (it "maps multiple mode mappings with a bare-string at once"
+    (it* "maps multiple mode mappings with a bare-string at once"
       (map! :nct :lhs :rhs)
       (each [mode (-> :nct (: :gmatch "."))]
         (assert.is.same :rhs (get-rhs mode :lhs))))
-    (it "enables `replace_keycodes` with `expr` in `extra-opts`"
+    (it* "enables `replace_keycodes` with `expr` in `extra-opts`"
       (let [modes [:n]]
         (map! modes [:expr] :lhs :rhs)
         (let [{: replace_keycodes} (get-mapargs :n :lhs)]
           (assert.is.same 1 replace_keycodes))))
-    (it "disables `replace_keycodes` with `literal` in `extra-opts`"
+    (it* "disables `replace_keycodes` with `literal` in `extra-opts`"
       (let [modes [:n]]
         (map! modes [:expr :literal] :lhs :rhs)
         (let [{: replace_keycodes} (get-mapargs :n :lhs)]
           (assert.is_nil replace_keycodes))))
-    (describe :<Cmd>pattern
-      (it "symbol will be set to 'command'"
+    (describe* :<Cmd>pattern
+      (it* "symbol will be set to 'command'"
         (map! :n :lhs <default>-command)
         (let [rhs (get-rhs :n :lhs)]
           (assert.is.same <default>-command rhs)))
-      (it "list will be set to 'command'"
+      (it* "list will be set to 'command'"
         (map! :n :lhs (<default>-str-callback))
         (let [rhs (get-rhs :n :lhs)]
           (assert.is.same (<default>-str-callback) rhs))))
-    (describe "with `&vim` indicator"
-      (it "sets `callback` in symbol as key sequence"
+    (describe* "with `&vim` indicator"
+      (it* "sets `callback` in symbol as key sequence"
         (map! :n :lhs &vim default-rhs)
         (assert.is_same default-rhs (get-rhs :n :lhs)))
-      (it "sets `callback` in multi symbol as key sequence"
+      (it* "sets `callback` in multi symbol as key sequence"
         (map! :n :lhs &vim default.multi.sym.command)
         (assert.is_same default.multi.sym.command (get-rhs :n :lhs)))
-      (it "sets `callback` in list as key sequence"
+      (it* "sets `callback` in list as key sequence"
         (map! :n :lhs &vim (macro-command))
         (assert.is_same (macro-command) (get-rhs :n :lhs)))))
-  (describe :unmap!
-    (it "`unmap`s key"
+  (describe* :unmap!
+    (it* "`unmap`s key"
       (map! :n :lhs :rhs)
       (assert.is.same :rhs (get-rhs :n :lhs))
       (unmap! :n :lhs)
       (assert.is_nil (get-rhs :n :lhs)))
-    (it "can unmap buffer local key"
+    (it* "can unmap buffer local key"
       (let [bufnr (vim.api.nvim_get_current_buf)]
         (map! :n [:<buffer>] :lhs :rhs)
         (assert.is.same :rhs (buf-get-rhs 0 :n :lhs))
@@ -175,39 +176,39 @@
         (assert.is.same :rhs (buf-get-rhs bufnr :n :lhs))
         (unmap! bufnr :n :lhs)
         (assert.is_nil (buf-get-rhs bufnr :n :lhs)))))
-  (describe :<Cmd>/<C-u>
-    (it "is set to rhs as a string"
+  (describe* :<Cmd>/<C-u>
+    (it* "is set to rhs as a string"
       (assert.has_no.errors #(map! :n :lhs (<Cmd> "Do something")))
       (assert.is.same "<Cmd>Do something<CR>" (get-rhs :n :lhs))
       (assert.has_no.errors #(map! :n [:<buffer>] :lhs (<C-u> "Do something")))
       (assert.is.same ":<C-U>Do something<CR>" (buf-get-rhs 0 :n :lhs))))
-  (describe "(wrapper)"
-    (describe :omni-map!
-      (it "should map to lhs in any mode"
+  (describe* "(wrapper)"
+    (describe* :omni-map!
+      (it* "should map to lhs in any mode"
         (each [_ mode (ipairs [:n :v :x :s :o :i :l :c :t])]
           (assert.is_nil (get-rhs mode :lhs)))
         (omni-map! :lhs :rhs)
         (each [_ mode (ipairs [:n :v :x :s :o :i :l :c :t])]
           (assert.is_same :rhs (get-rhs mode :lhs)))))
-    (describe :nmap!
-      (it "can include extra-opts in either first or second arg"
+    (describe* :nmap!
+      (it* "can include extra-opts in either first or second arg"
         (assert.has_no.errors #(nmap! [:nowait] :lhs :rhs))
         (assert.has_no.errors #(nmap! :lhs [:nowait] :rhs)))
-      (it "maps to current buffer with `<buffer>`"
+      (it* "maps to current buffer with `<buffer>`"
         (nmap! [:<buffer>] :lhs :rhs)
         (assert.is.same :rhs (buf-get-rhs 0 :n :lhs)))
-      (it "maps to specific buffer with `buffer`"
+      (it* "maps to specific buffer with `buffer`"
         (let [bufnr (vim.api.nvim_get_current_buf)]
           (refresh-buffer)
           (nmap! [:buffer bufnr] :lhs :rhs)
           (assert.is_nil (buf-get-rhs 0 :n :lhs))
           (assert.is.same :rhs (buf-get-rhs bufnr :n :lhs))))
-      (it "set a list which will result in string without callback"
+      (it* "set a list which will result in string without callback"
         (nmap! :lhs &vim (.. :r :h :s))
         (nmap! :lhs1 &vim (.. (<Cmd> :foobar) :<Esc>))
         (assert.is.same :rhs (get-rhs :n :lhs))
         (assert.is.same :<Cmd>foobar<CR><Esc> (get-rhs :n :lhs1)))
-      (it "enables `replace_keycodes` when `expr` is set in `extra-opts`"
+      (it* "enables `replace_keycodes` when `expr` is set in `extra-opts`"
         (nmap! :lhs [:expr] :rhs)
         (nmap! :lhs1 :rhs {:expr true})
         (let [opt {:expr true}]
@@ -218,14 +219,14 @@
           (assert.is_nil replace_keycodes))
         (let [{: replace_keycodes} (get-mapargs :n :lhs2)]
           (assert.is_nil replace_keycodes)))
-      (it "disables `replace_keycodes` when `literal` is set in `extra-opts`"
+      (it* "disables `replace_keycodes` when `literal` is set in `extra-opts`"
         (nmap! :lhs [:expr :literal] :rhs)
         (let [{: replace_keycodes} (get-mapargs :n :lhs)]
           (assert.is_nil replace_keycodes))))
-    (describe "with `&default-opts`,"
-      (describe "imported macro"
-        (describe :remap!
-          (it "creates recursive mapping by default"
+    (describe* "with `&default-opts`,"
+      (describe* "imported macro"
+        (describe* :remap!
+          (it* "creates recursive mapping by default"
             (let [mode :x
                   modes [:n :o :t]]
               (remap! mode :lhs :rhs)
@@ -235,7 +236,7 @@
               (each [_ m (ipairs modes)]
                 (let [{: noremap} (get-mapargs m :lhs)]
                   (assert.is.same 0 noremap)))))
-          (it "can create non-recursive mappings by overriding option"
+          (it* "can create non-recursive mappings by overriding option"
             (let [mode :x
                   modes [:n :o :t]]
               (map! mode [:noremap] :lhs :rhs)
@@ -245,10 +246,10 @@
               (each [_ m (ipairs modes)]
                 (let [{: noremap} (get-mapargs m :lhs)]
                   (assert.is.same 1 noremap))))))
-        (describe "buf-map! with {:buffer 0} in its default-opts"
-          (before_each (fn []
+        (describe* "buf-map! with {:buffer 0} in its default-opts"
+          (before-each (fn []
                          (refresh-buffer)))
-          (it "creates current buffer-local mapping by default"
+          (it* "creates current buffer-local mapping by default"
             (let [mode :x
                   bufnr (vim.api.nvim_get_current_buf)]
               (assert.is_nil (get-rhs mode :lhs))
@@ -259,7 +260,7 @@
               (refresh-buffer)
               (assert.is_nil (buf-get-rhs 0 mode :lhs))
               (assert.is_same :rhs (buf-get-rhs bufnr mode :lhs))))
-          (it "can create another buffer-local mapping by overriding option"
+          (it* "can create another buffer-local mapping by overriding option"
             (let [mode :x
                   bufnr (vim.api.nvim_get_current_buf)]
               (refresh-buffer)
@@ -270,8 +271,8 @@
               (assert.is_nil (buf-get-rhs 0 mode :lhs))
               (refresh-buffer)
               (assert.is_same :rhs (buf-get-rhs bufnr mode :lhs)))))
-        (describe "buf-map! with {:<buffer> true} in its default-opts"
-          (it "creates current buffer-local mapping by default"
+        (describe* "buf-map! with {:<buffer> true} in its default-opts"
+          (it* "creates current buffer-local mapping by default"
             (let [bufnr (vim.api.nvim_get_current_buf)]
               (assert.is_nil (get-rhs :x :lhs))
               (assert.is_nil (buf-get-rhs 0 :x :lhs))
@@ -281,7 +282,7 @@
               (refresh-buffer)
               (assert.is_nil (buf-get-rhs 0 :x :lhs))
               (assert.is_same :rhs (buf-get-rhs bufnr :x :lhs))))
-          (it "can create another buffer-local mapping by overriding option"
+          (it* "can create another buffer-local mapping by overriding option"
             (let [mode :x
                   bufnr (vim.api.nvim_get_current_buf)]
               (assert.is_nil (get-rhs mode :lhs))

--- a/tests/spec/option_spec.fnl
+++ b/tests/spec/option_spec.fnl
@@ -1,4 +1,4 @@
-(import-macros {: before_each : describe : it} :_busted_macros)
+(import-macros {: before-each : describe* : it*} :_busted_macros)
 (import-macros {: set+ : set- : set^} :_wrapper_macros)
 (import-macros {: set!
                 : setglobal!
@@ -66,60 +66,60 @@
   (each [name val (pairs default-opt-map)]
     (assert.is_same val (. vim.o name))))
 
-(describe :options
-  (before_each (do
+(describe* :options
+  (before-each (do
                  (reset-context)))
-  (describe :set!
-    (it "is case-insensitive at option name"
+  (describe* :set!
+    (it* "is case-insensitive at option name"
       (vim.cmd "set foldlevel=2")
       (let [vals (get-o-lo-go :foldlevel)]
         (reset-context)
         (set! :foldLevel 2)
         (assert.is_same vals (get-o-lo-go :foldlevel))))
-    (it "can update option value with boolean"
+    (it* "can update option value with boolean"
       (vim.cmd "set nowrap")
       (let [vals (get-o-lo-go :wrap)]
         (reset-context)
         (set! :wrap false)
         (assert.is_same vals (get-o-lo-go :wrap))))
-    (it "can update option value with number"
+    (it* "can update option value with number"
       (vim.cmd "set foldlevel=2")
       (let [vals (get-o-lo-go :foldlevel)]
         (reset-context)
         (set! :foldlevel 2)
         (assert.is_same vals (get-o-lo-go :foldlevel))))
-    (it "can update option value with string"
+    (it* "can update option value with string"
       (vim.cmd "set signcolumn=no")
       (let [vals (get-o-lo-go :signcolumn)]
         (reset-context)
         (set! :signcolumn :no)
         (assert.is_same vals (get-o-lo-go :signcolumn))))
-    (it "can update option value with sequence"
+    (it* "can update option value with sequence"
       (vim.cmd "set path=/foo,/bar,/baz")
       (let [vals (get-o-lo-go :path)]
         (reset-context)
         (set! :path [:/foo :/bar :/baz])
         (assert.is_same vals (get-o-lo-go :path))))
-    (it "can update option value with kv-table"
+    (it* "can update option value with kv-table"
       (vim.cmd "set listchars=eol:a,tab:abc,space:a")
       (let [vals (get-o-lo-go :listchars)]
         (reset-context)
         (set! :listchars {:eol :a :tab :abc :space :a})
         (assert.is_same vals (get-o-lo-go :listchars))))
-    (it "can update some option value with nil"
+    (it* "can update some option value with nil"
       (set vim.opt.foldlevel nil)
       (let [vals (get-o-lo-go :foldlevel)]
         (reset-context)
         (set! :foldlevel nil)
         (assert.is_same vals (get-o-lo-go :foldlevel))))
-    (it "can update some option value with symbol"
+    (it* "can update some option value with symbol"
       (let [new-val 2]
         (set vim.opt.foldlevel new-val)
         (let [vals (get-o-lo-go :foldlevel)]
           (reset-context)
           (set! :foldlevel new-val)
           (assert.is_same vals (get-o-lo-go :foldlevel)))))
-    (it "can update some option value with list"
+    (it* "can update some option value with list"
       (let [return-val #2]
         (set vim.opt.foldlevel (return-val))
         (let [vals (get-o-lo-go :foldlevel)]
@@ -127,480 +127,480 @@
           (set! :foldlevel (return-val))
           (assert.is_same vals (get-o-lo-go :foldlevel))
           (assert.is_same vals (get-o-lo-go :foldlevel)))))
-    (it "can append option value of sequence"
+    (it* "can append option value of sequence"
       (vim.cmd "set path+=/foo,/bar,/baz")
       (let [vals (get-o-lo-go :path)]
         (reset-context)
         (set! :path + [:/foo :/bar :/baz])
         (assert.is_same vals (get-o-lo-go :path))))
-    (it "can prepend option value of sequence"
+    (it* "can prepend option value of sequence"
       (vim.cmd "set path^=/foo,/bar,/baz")
       (let [vals (get-o-lo-go :path)]
         (reset-context)
         (set! :path ^ [:/foo :/bar :/baz])
         (assert.is_same vals (get-o-lo-go :path))))
-    (it "can remove option value of sequence"
+    (it* "can remove option value of sequence"
       (vim.cmd "set path-=/tmp,/var")
       (let [vals (get-o-lo-go :path)]
         (reset-context)
         (set! :path - [:/tmp :/var])
         (assert.is_same vals (get-o-lo-go :path))))
-    (it "can append option value of kv-table"
+    (it* "can append option value of kv-table"
       (vim.opt.listchars:append {:lead :a :trail :b :extends :c})
       (let [vals (get-o-lo-go :listchars)]
         (reset-context)
         (set! :listchars + {:lead :a :trail :b :extends :c})
         (assert.is_same vals (get-o-lo-go :listchars))))
-    (it "can prepend option value of kv-table"
+    (it* "can prepend option value of kv-table"
       (vim.opt.listchars:prepend {:lead :a :trail :b :extends :c})
       (let [vals (get-o-lo-go :listchars)]
         (reset-context)
         (set! :listchars ^ {:lead :a :trail :b :extends :c})
         (assert.is_same vals (get-o-lo-go :listchars))))
-    (it "can remove option value of kv-table"
+    (it* "can remove option value of kv-table"
       (vim.opt.listchars:remove [:eol :tab])
       (let [vals (get-o-lo-go :listchars)]
         (reset-context)
         (set! :listchars - [:eol :tab])
         (assert.is_same vals (get-o-lo-go :listchars))))
-    (describe "with no value"
-      (it "updates option value to `true`"
+    (describe* "with no value"
+      (it* "updates option value to `true`"
         (vim.cmd "set nowrap")
         (assert.is_false (get-o :wrap))
         (set! :wrap)
         (assert.is_true (get-o :wrap)))
-      (it "updates value to `true` even when option name is hidden in compile time"
+      (it* "updates value to `true` even when option name is hidden in compile time"
         (vim.cmd "set nowrap")
         (assert.is_false (get-o :wrap))
         (let [name :wrap]
           (set! name)
           (assert.is_true (get-o name))))))
-  (describe :setlocal!
-    (it "can update option value with boolean"
+  (describe* :setlocal!
+    (it* "can update option value with boolean"
       (vim.cmd "setlocal nowrap")
       (let [vals (get-o-lo-go :wrap)]
         (reset-context)
         (setlocal! :wrap false)
         (assert.is_same vals (get-o-lo-go :wrap))))
-    (it "can update option value with number"
+    (it* "can update option value with number"
       (vim.cmd "setlocal foldlevel=2")
       (let [vals (get-o-lo-go :foldlevel)]
         (reset-context)
         (setlocal! :foldlevel 2)
         (assert.is_same vals (get-o-lo-go :foldlevel))))
-    (it "can update option value with string"
+    (it* "can update option value with string"
       (vim.cmd "setlocal signcolumn=no")
       (let [vals (get-o-lo-go :signcolumn)]
         (reset-context)
         (setlocal! :signcolumn :no)
         (assert.is_same vals (get-o-lo-go :signcolumn))))
-    (it "can update option value with sequence"
+    (it* "can update option value with sequence"
       (vim.cmd "setlocal path=/foo,/bar,/baz")
       (let [vals (get-o-lo-go :path)]
         (reset-context)
         (setlocal! :path [:/foo :/bar :/baz])
         (assert.is_same vals (get-o-lo-go :path))))
-    (it "can update option value with kv-table"
+    (it* "can update option value with kv-table"
       (vim.cmd "setlocal listchars=eol:a,tab:abc,space:a")
       (let [vals (get-o-lo-go :listchars)]
         (reset-context)
         (setlocal! :listchars {:eol :a :tab :abc :space :a})
         (assert.is_same vals (get-o-lo-go :listchars))))
-    (it "can update some option value with nil"
+    (it* "can update some option value with nil"
       (set vim.opt_local.foldlevel nil)
       (let [vals (get-o-lo-go :foldlevel)]
         (reset-context)
         (setlocal! :foldlevel nil)
         (assert.is_same vals (get-o-lo-go :foldlevel))))
-    (it "can update some option value with symbol"
+    (it* "can update some option value with symbol"
       (let [new-val 2]
         (set vim.opt_local.foldlevel new-val)
         (let [vals (get-o-lo-go :foldlevel)]
           (reset-context)
           (setlocal! :foldlevel new-val)
           (assert.is_same vals (get-o-lo-go :foldlevel)))))
-    (it "can update some option value with list"
+    (it* "can update some option value with list"
       (let [return-val #2]
         (set vim.opt_local.foldlevel (return-val))
         (let [vals (get-o-lo-go :foldlevel)]
           (reset-context)
           (setlocal! :foldlevel (return-val))
           (assert.is_same vals (get-o-lo-go :foldlevel)))))
-    (it "can append option value of sequence"
+    (it* "can append option value of sequence"
       (vim.opt_local.path:append [:/foo :/bar :/baz])
       (let [vals (get-o-lo-go :path)]
         (reset-context)
         (setlocal! :path + [:/foo :/bar :/baz])
         (assert.is_same vals (get-o-lo-go :path))))
-    (it "can prepend option value of sequence"
+    (it* "can prepend option value of sequence"
       (vim.opt_local.path:prepend [:/foo :/bar :/baz])
       (let [vals (get-o-lo-go :path)]
         (reset-context)
         (setlocal! :path ^ [:/foo :/bar :/baz])
         (assert.is_same vals (get-o-lo-go :path))))
-    (it "can remove option value of sequence"
+    (it* "can remove option value of sequence"
       (vim.opt_local.path:remove [:/tmp :/var])
       (let [vals (get-o-lo-go :path)]
         (reset-context)
         (setlocal! :path - [:/tmp :/var])
         (assert.is_same vals (get-o-lo-go :path))))
-    (it "can append option value of kv-table"
+    (it* "can append option value of kv-table"
       (vim.opt_local.listchars:append {:lead :a :trail :b :extends :c})
       (let [vals (get-o-lo-go :listchars)]
         (reset-context)
         (setlocal! :listchars + {:lead :a :trail :b :extends :c})
         (assert.is_same vals (get-o-lo-go :listchars))))
-    (it "can prepend option value of kv-table"
+    (it* "can prepend option value of kv-table"
       (vim.opt_local.listchars:prepend {:lead :a :trail :b :extends :c})
       (let [vals (get-o-lo-go :listchars)]
         (reset-context)
         (setlocal! :listchars ^ {:lead :a :trail :b :extends :c})
         (assert.is_same vals (get-o-lo-go :listchars))))
-    (it "can remove option value of kv-table"
+    (it* "can remove option value of kv-table"
       (vim.opt_local.listchars:remove [:eol :tab])
       (let [vals (get-o-lo-go :listchars)]
         (reset-context)
         (setlocal! :listchars - [:eol :tab])
         (assert.is_same vals (get-o-lo-go :listchars))))
-    (describe "with no value"
-      (it "updates option value to `true`"
+    (describe* "with no value"
+      (it* "updates option value to `true`"
         (vim.cmd "setlocal nowrap")
         (assert.is_false (get-lo :wrap))
         (setlocal! :wrap)
         (assert.is_true (get-lo :wrap)))
-      (it "updates value to `true` even when option name is hidden in compile time"
+      (it* "updates value to `true` even when option name is hidden in compile time"
         (vim.cmd "setlocal nowrap")
         (assert.is_false (get-lo :wrap))
         (let [name :wrap]
           (setlocal! name)
           (assert.is_true (get-lo name)))))
-    (describe "for &l:formatoptions"
-      (it "can append flags in sequence"
+    (describe* "for &l:formatoptions"
+      (it* "can append flags in sequence"
         ;; Note: In truth, the formatoptions flag order doesn't matter.
         (setlocal! :formatOptions + [:a :r :B])
         (assert.is_same {:1 true :2 true :b true :a true :r true :B true}
                         (get-lo :formatoptions)))
-      (it "can prepend flags in sequence"
+      (it* "can prepend flags in sequence"
         ;; Note: In truth, the formatoptions flag order doesn't matter.
         (setlocal! :formatOptions ^ [:a :r :B])
         (assert.is_same {:1 true :2 true :b true :a true :r true :B true}
                         (get-lo :formatoptions)))
-      (it "can remove flags in sequence"
+      (it* "can remove flags in sequence"
         (setlocal! :formatOptions - [:b :2])
         (assert.is_same {:1 true} (get-lo :formatoptions)))
-      (it "can set symbol in sequence"
+      (it* "can set symbol in sequence"
         (let [val :r]
           (setlocal! :formatOptions [val])
           (assert.is_same {val true} (get-lo :formatoptions))))))
-  (describe :setglobal!
-    (it "can update option value with boolean"
+  (describe* :setglobal!
+    (it* "can update option value with boolean"
       (vim.cmd "setglobal nowrap")
       (let [vals (get-o-lo-go :wrap)]
         (reset-context)
         (setglobal! :wrap false)
         (assert.is_same vals (get-o-lo-go :wrap))))
-    (it "can update option value with number"
+    (it* "can update option value with number"
       (vim.cmd "setglobal foldlevel=2")
       (let [vals (get-o-lo-go :foldlevel)]
         (reset-context)
         (setglobal! :foldlevel 2)
         (assert.is_same vals (get-o-lo-go :foldlevel))))
-    (it "can update option value with string"
+    (it* "can update option value with string"
       (vim.cmd "setglobal signcolumn=no")
       (let [vals (get-o-lo-go :signcolumn)]
         (reset-context)
         (setglobal! :signcolumn :no)
         (assert.is_same vals (get-o-lo-go :signcolumn))))
-    (it "can update option value with sequence"
+    (it* "can update option value with sequence"
       (vim.cmd "setglobal path=/foo,/bar,/baz")
       (let [vals (get-o-lo-go :path)]
         (reset-context)
         (setglobal! :path [:/foo :/bar :/baz])
         (assert.is_same vals (get-o-lo-go :path))))
-    (it "can update option value with kv-table"
+    (it* "can update option value with kv-table"
       (vim.cmd "setglobal listchars=eol:a,tab:abc,space:a")
       (let [vals (get-o-lo-go :listchars)]
         (reset-context)
         (setglobal! :listchars {:eol :a :tab :abc :space :a})
         (assert.is_same vals (get-o-lo-go :listchars))))
     (if (= 1 (vim.fn.has :nvim-0.10.0-dev))
-        (it "throws an error with nil assigned"
+        (it* "throws an error with nil assigned"
           (assert.error #(set vim.opt_global.foldlevel nil)))
-        (it "can update some option value with nil"
+        (it* "can update some option value with nil"
           (set vim.opt_global.foldlevel nil)
           (let [vals (get-o-lo-go :foldlevel)]
             (reset-context)
             (setglobal! :foldlevel nil)
             (assert.is_same vals (get-o-lo-go :foldlevel)))))
-    (it "can update some option value with symbol"
+    (it* "can update some option value with symbol"
       (let [new-val 2]
         (set vim.opt_global.foldlevel new-val)
         (let [vals (get-o-lo-go :foldlevel)]
           (reset-context)
           (setglobal! :foldlevel new-val)
           (assert.is_same vals (get-o-lo-go :foldlevel)))))
-    (it "can update some option value with list"
+    (it* "can update some option value with list"
       (let [return-val #2]
         (set vim.opt_global.foldlevel (return-val))
         (let [vals (get-o-lo-go :foldlevel)]
           (reset-context)
           (setglobal! :foldlevel (return-val))
           (assert.is_same vals (get-o-lo-go :foldlevel)))))
-    (it "can append option value of sequence"
+    (it* "can append option value of sequence"
       (vim.opt_global.path:append [:/foo :/bar :/baz])
       (let [vals (get-o-lo-go :path)]
         (reset-context)
         (setglobal! :path + [:/foo :/bar :/baz])
         (assert.is_same vals (get-o-lo-go :path))))
-    (it "can prepend option value of sequence"
+    (it* "can prepend option value of sequence"
       (vim.opt_global.path:prepend [:/foo :/bar :/baz])
       (let [vals (get-o-lo-go :path)]
         (reset-context)
         (setglobal! :path ^ [:/foo :/bar :/baz])
         (assert.is_same vals (get-o-lo-go :path))))
-    (it "can remove option value of sequence"
+    (it* "can remove option value of sequence"
       (vim.opt_global.path:remove [:/tmp :/var])
       (let [vals (get-o-lo-go :path)]
         (reset-context)
         (setglobal! :path - [:/tmp :/var])
         (assert.is_same vals (get-o-lo-go :path))))
-    (it "can append option value of kv-table"
+    (it* "can append option value of kv-table"
       (vim.opt_global.listchars:append {:lead :a :trail :b :extends :c})
       (let [vals (get-o-lo-go :listchars)]
         (reset-context)
         (setglobal! :listchars + {:lead :a :trail :b :extends :c})
         (assert.is_same vals (get-o-lo-go :listchars))))
-    (it "can prepend option value of kv-table"
+    (it* "can prepend option value of kv-table"
       (vim.opt_global.listchars:prepend {:lead :a :trail :b :extends :c})
       (let [vals (get-o-lo-go :listchars)]
         (reset-context)
         (setglobal! :listchars ^ {:lead :a :trail :b :extends :c})
         (assert.is_same vals (get-o-lo-go :listchars))))
-    (it "can remove option value of kv-table"
+    (it* "can remove option value of kv-table"
       (vim.opt_global.listchars:remove [:eol :tab])
       (let [vals (get-o-lo-go :listchars)]
         (reset-context)
         (setglobal! :listchars - [:eol :tab])
         (assert.is_same vals (get-o-lo-go :listchars))))
-    (describe "for &l:shortmess"
-      (it "can append flags in sequence"
+    (describe* "for &l:shortmess"
+      (it* "can append flags in sequence"
         ;; Note: In truth, the shortmess flag order doesn't matter.
         (setglobal! :shortMess + [:m :n :r])
         (assert.is_same {:f true :i true :w true :m true :n true :r true}
                         (get-lo :shortmess)))
-      (it "can prepend flags in sequence"
+      (it* "can prepend flags in sequence"
         ;; Note: In truth, the shortmess flag order doesn't matter.
         (setglobal! :shortMess ^ [:m :n :r])
         (assert.is_same {:f true :i true :w true :m true :n true :r true}
                         (get-lo :shortmess)))
-      (it "can remove flags in sequence"
+      (it* "can remove flags in sequence"
         (setglobal! :shortMess - [:i :f])
         (assert.is_same {:w true} (get-lo :shortmess))))
-    (describe "with no value"
-      (it "updates option value to `true`"
+    (describe* "with no value"
+      (it* "updates option value to `true`"
         (vim.cmd "setglobal nowrap")
         (assert.is_false (get-go :wrap))
         (setglobal! :wrap)
         (assert.is_true (get-go :wrap)))
-      (it "updates value to `true` even when option name is hidden in compile time"
+      (it* "updates value to `true` even when option name is hidden in compile time"
         (vim.cmd "setglobal nowrap")
         (assert.is_false (get-go :wrap))
         (let [name :wrap]
           (setglobal! name)
           (assert.is_true (get-go name))))))
-  (describe :bo!
-    (it "can update option value with boolean"
+  (describe* :bo!
+    (it* "can update option value with boolean"
       (tset vim.bo :expandtab false)
       (let [vals (get-o-lo-go :expandtab)]
         (reset-context)
         (bo! :expandtab false)
         (assert.is_same vals (get-o-lo-go :expandtab))))
-    (it "can update option value with number"
+    (it* "can update option value with number"
       (tset vim.bo :tabstop 2)
       (let [vals (get-o-lo-go :tabstop)]
         (reset-context)
         (bo! :tabstop 2)
         (assert.is_same vals (get-o-lo-go :tabstop))))
-    (it "can update option value with string"
+    (it* "can update option value with string"
       (tset vim.bo :omnifunc :abc)
       (let [vals (get-o-lo-go :omnifunc)]
         (reset-context)
         (bo! :omnifunc :abc)
         (assert.is_same vals (get-o-lo-go :omnifunc))))
-    (it "can update option value with sequence"
+    (it* "can update option value with sequence"
       (tset vim.bo :path "/foo,/bar,/baz")
       (let [vals (get-o-lo-go :path)]
         (reset-context)
         (bo! :path [:/foo :/bar :/baz])
         (assert.is_same vals (get-o-lo-go :path))))
-    (it "can update option value with kv-table"
+    (it* "can update option value with kv-table"
       (tset vim.bo :matchpairs "a:A,b:B,c:C")
       (let [vals (get-o-lo-go :matchpairs)]
         (reset-context)
         (bo! :matchPairs {:a :A :b :B :c :C})
         (assert.is_same vals (get-o-lo-go :matchpairs))))
-    (it "can update some option value with nil"
+    (it* "can update some option value with nil"
       (set vim.bo.tabstop nil)
       (let [vals (get-o-lo-go :tabstop)]
         (reset-context)
         (bo! :tabstop nil)
         (assert.is_same vals (get-o-lo-go :tabstop))))
-    (it "can update some option value with symbol"
+    (it* "can update some option value with symbol"
       (let [new-val 2]
         (set vim.bo.tabstop new-val)
         (let [vals (get-o-lo-go :tabstop)]
           (reset-context)
           (bo! :tabstop new-val)
           (assert.is_same vals (get-o-lo-go :tabstop)))))
-    (it "can update some option value with list"
+    (it* "can update some option value with list"
       (let [return-val #2]
         (set vim.bo.tabstop (return-val))
         (let [vals (get-o-lo-go :tabstop)]
           (reset-context)
           (bo! :tabstop (return-val))
           (assert.is_same vals (get-o-lo-go :tabstop)))))
-    (describe "with bufnr"
-      (it "can update option value with boolean"
+    (describe* "with bufnr"
+      (it* "can update option value with boolean"
         (let [buf (vim.api.nvim_get_current_buf)]
           (reset-context)
           (bo! buf :expandtab false)
           (assert.is_false (. vim.bo buf :expandtab))))
-      (it "can update option value with number"
+      (it* "can update option value with number"
         (let [buf (vim.api.nvim_get_current_buf)]
           (reset-context)
           (bo! buf :tabstop 2)
           (assert.is_same 2 (. vim.bo buf :tabstop))))
-      (it "can update option value with string"
+      (it* "can update option value with string"
         (let [buf (vim.api.nvim_get_current_buf)]
           (reset-context)
           (bo! buf :omnifunc :abc)
           (assert.is_same :abc (. vim.bo buf :omnifunc))))
-      (it "can update option value with sequence"
+      (it* "can update option value with sequence"
         (let [buf (vim.api.nvim_get_current_buf)]
           (reset-context)
           (bo! buf :path [:/foo :/bar :/baz])
           (assert.is_same "/foo,/bar,/baz" (. vim.bo buf :path))))
-      (it "can update option value with kv-table"
+      (it* "can update option value with kv-table"
         (let [buf (vim.api.nvim_get_current_buf)]
           (reset-context)
           (bo! buf :matchPairs {:a :A :b :B :c :C})
           (assert.is_same "a:A,b:B,c:C" (. vim.bo buf :matchpairs))))
-      (it "can update some option value with nil"
+      (it* "can update some option value with nil"
         (let [buf (vim.api.nvim_get_current_buf)]
           (reset-context)
           (bo! buf :tabstop nil)
           (assert.is_same vim.go.tabstop (. vim.bo buf :tabstop))))
-      (it "can update some option value with symbol"
+      (it* "can update some option value with symbol"
         (let [buf (vim.api.nvim_get_current_buf)
               new-val 2]
           (reset-context)
           (bo! buf :tabstop new-val)
           (assert.is_same new-val (. vim.bo buf :tabstop))))
-      (it "can update some option value with list"
+      (it* "can update some option value with list"
         (let [buf (vim.api.nvim_get_current_buf)
               new-val 2
               return-val #new-val]
           (reset-context)
           (bo! buf :tabstop (return-val))
           (assert.is_same new-val (. vim.bo buf :tabstop))))))
-  (describe :wo!
-    (it "can update option value with boolean"
+  (describe* :wo!
+    (it* "can update option value with boolean"
       (tset vim.wo :wrap false)
       (let [vals (get-o-lo-go :wrap)]
         (reset-context)
         (wo! :wrap false)
         (assert.is_same vals (get-o-lo-go :wrap))))
-    (it "can update option value with number"
+    (it* "can update option value with number"
       (tset vim.wo :foldlevel 2)
       (let [vals (get-o-lo-go :foldlevel)]
         (reset-context)
         (wo! :foldlevel 2)
         (assert.is_same vals (get-o-lo-go :foldlevel))))
-    (it "can update option value with string"
+    (it* "can update option value with string"
       (tset vim.wo :signcolumn :no)
       (let [vals (get-o-lo-go :signcolumn)]
         (reset-context)
         (wo! :signcolumn :no)
         (assert.is_same vals (get-o-lo-go :signcolumn))))
-    (it "can update option value with sequence"
+    (it* "can update option value with sequence"
       (tset vim.wo :colorcolumn "80,81,82")
       (let [vals (get-o-lo-go :colorcolumn)]
         (reset-context)
         (wo! :colorcolumn [:80 :81 :82])
         (assert.is_same vals (get-o-lo-go :colorcolumn))))
-    (it "can update option value with kv-table"
+    (it* "can update option value with kv-table"
       (tset vim.wo :listchars "eol:a,tab:abc,space:a")
       (let [vals (get-o-lo-go :listchars)]
         (reset-context)
         (wo! :listchars {:eol :a :tab :abc :space :a})
         (assert.is_same vals (get-o-lo-go :listchars))))
-    (it "can update some option value with nil"
+    (it* "can update some option value with nil"
       (set vim.wo.foldlevel nil)
       (let [vals (get-o-lo-go :foldlevel)]
         (reset-context)
         (wo! :foldlevel nil)
         (assert.is_same vals (get-o-lo-go :foldlevel))))
-    (it "can update some option value with symbol"
+    (it* "can update some option value with symbol"
       (let [new-val 2]
         (set vim.wo.foldlevel new-val)
         (let [vals (get-o-lo-go :foldlevel)]
           (reset-context)
           (wo! :foldlevel new-val)
           (assert.is_same vals (get-o-lo-go :foldlevel)))))
-    (it "can update some option value with list"
+    (it* "can update some option value with list"
       (let [return-val #2]
         (set vim.wo.foldlevel (return-val))
         (let [vals (get-o-lo-go :foldlevel)]
           (reset-context)
           (wo! :foldlevel (return-val))
           (assert.is_same vals (get-o-lo-go :foldlevel)))))
-    (describe "with win-id"
-      (it "can update option value with woolean"
+    (describe* "with win-id"
+      (it* "can update option value with woolean"
         (let [win (vim.api.nvim_get_current_win)]
           (vim.cmd.new)
           (wo! win :wrap false)
           (assert.is_false (. vim.wo win :wrap))))
-      (it "can update option value with number"
+      (it* "can update option value with number"
         (let [win (vim.api.nvim_get_current_win)]
           (vim.cmd.new)
           (wo! win :foldlevel 2)
           (assert.is_same 2 (. vim.wo win :foldlevel))))
-      (it "can update option value with string"
+      (it* "can update option value with string"
         (let [win (vim.api.nvim_get_current_win)]
           (vim.cmd.new)
           (wo! win :signcolumn :no)
           (assert.is_same :no (. vim.wo win :signcolumn))))
-      (it "can update option value with sequence"
+      (it* "can update option value with sequence"
         (let [win (vim.api.nvim_get_current_win)]
           (vim.cmd.new)
           (wo! win :colorcolumn [:80 :81 :82])
           (assert.is_same "80,81,82" (. vim.wo win :colorcolumn))))
-      (it "can update option value with kv-table"
+      (it* "can update option value with kv-table"
         (let [win (vim.api.nvim_get_current_win)]
           (vim.cmd.new)
           (wo! win :listchars {:eol :a :tab :abc :space :a})
           (assert.is_same "eol:a,tab:abc,space:a" (. vim.wo win :listchars))))
-      (it "can update some option value with nil"
+      (it* "can update some option value with nil"
         (let [win (vim.api.nvim_get_current_win)]
           (vim.cmd.new)
           (wo! win :foldlevel nil)
           (assert.is_same vim.go.foldlevel (. vim.wo win :foldlevel))))
-      (it "can update some option value with symbol"
+      (it* "can update some option value with symbol"
         (let [win (vim.api.nvim_get_current_win)
               new-val 2]
           (vim.cmd.new)
           (wo! win :foldlevel new-val)
           (assert.is_same new-val (. vim.wo win :foldlevel))))
-      (it "can update some option value with list"
+      (it* "can update some option value with list"
         (let [win (vim.api.nvim_get_current_win)
               new-val 2
               return-val #new-val]
           (vim.cmd.new)
           (wo! win :foldlevel (return-val))
           (assert.is_same new-val (. vim.wo win :foldlevel))))))
-  (describe "(wrapper)"
-    (describe :set+
-      (it "appends option value of sequence"
+  (describe* "(wrapper)"
+    (describe* :set+
+      (it* "appends option value of sequence"
         (let [name :path
               assigned-val [:/foo :/bar :/baz]]
           (-> (. vim.opt name) (: :append assigned-val))
@@ -608,7 +608,7 @@
             (reset-context)
             (set+ name assigned-val)
             (assert.is_same expected-vals (get-o-lo-go name)))))
-      (it "appends option value of kv-table"
+      (it* "appends option value of kv-table"
         (let [name :listchars
               assigned-val {:lead :a :trail :b :extends :c}]
           (-> (. vim.opt name) (: :append assigned-val))
@@ -616,8 +616,8 @@
             (reset-context)
             (set+ name assigned-val)
             (assert.is_same expected-vals (get-o-lo-go name))))))
-    (describe :set^
-      (it "prepends option value of sequence"
+    (describe* :set^
+      (it* "prepends option value of sequence"
         (let [name :path
               assigned-val [:/foo :/bar :/baz]]
           (-> (. vim.opt name) (: :prepend assigned-val))
@@ -625,7 +625,7 @@
             (reset-context)
             (set^ name assigned-val)
             (assert.is_same expected-vals (get-o-lo-go name)))))
-      (it "prepends option value of kv-table"
+      (it* "prepends option value of kv-table"
         (let [name :listchars
               assigned-val {:lead :a :trail :b :extends :c}]
           (-> (. vim.opt name) (: :prepend assigned-val))
@@ -633,8 +633,8 @@
             (reset-context)
             (set^ name assigned-val)
             (assert.is_same expected-vals (get-o-lo-go name))))))
-    (describe :set-
-      (it "removes option value of sequence"
+    (describe* :set-
+      (it* "removes option value of sequence"
         (let [name :path
               assigned-val [:/tmp :/var]]
           (-> (. vim.opt name) (: :remove assigned-val))
@@ -642,7 +642,7 @@
             (reset-context)
             (set- name assigned-val)
             (assert.is_same expected-vals (get-o-lo-go name)))))
-      (it "removes option value of kv-table"
+      (it* "removes option value of kv-table"
         (let [name :listchars
               assigned-val {:lead :a :trail :b :extends :c}]
           (-> (. vim.opt name) (: :remove assigned-val))
@@ -650,9 +650,9 @@
             (reset-context)
             (set- name assigned-val)
             (assert.is_same expected-vals (get-o-lo-go name)))))))
-  (describe "(deprecated, v0.7.0 will not support it)"
-    (describe :set+
-      (it "appends option value of sequence"
+  (describe* "(deprecated, v0.7.0 will not support it*)"
+    (describe* :set+
+      (it* "appends option value of sequence"
         (let [name :path
               assigned-val [:/foo :/bar :/baz]]
           (-> (. vim.opt name) (: :append assigned-val))
@@ -660,7 +660,7 @@
             (reset-context)
             (deprecated/set+ name assigned-val)
             (assert.is_same expected-vals (get-o-lo-go name)))))
-      (it "appends option value of kv-table"
+      (it* "appends option value of kv-table"
         (let [name :listchars
               assigned-val {:lead :a :trail :b :extends :c}]
           (-> (. vim.opt name) (: :append assigned-val))
@@ -668,8 +668,8 @@
             (reset-context)
             (deprecated/set+ name assigned-val)
             (assert.is_same expected-vals (get-o-lo-go name))))))
-    (describe :set^
-      (it "prepends option value of sequence"
+    (describe* :set^
+      (it* "prepends option value of sequence"
         (let [name :path
               assigned-val [:/foo :/bar :/baz]]
           (-> (. vim.opt name) (: :prepend assigned-val))
@@ -677,7 +677,7 @@
             (reset-context)
             (deprecated/set^ name assigned-val)
             (assert.is_same expected-vals (get-o-lo-go name)))))
-      (it "prepends option value of kv-table"
+      (it* "prepends option value of kv-table"
         (let [name :listchars
               assigned-val {:lead :a :trail :b :extends :c}]
           (-> (. vim.opt name) (: :prepend assigned-val))
@@ -685,8 +685,8 @@
             (reset-context)
             (deprecated/set^ name assigned-val)
             (assert.is_same expected-vals (get-o-lo-go name))))))
-    (describe :set-
-      (it "removes option value of sequence"
+    (describe* :set-
+      (it* "removes option value of sequence"
         (let [name :path
               assigned-val [:/tmp :/var]]
           (-> (. vim.opt name) (: :remove assigned-val))
@@ -694,7 +694,7 @@
             (reset-context)
             (deprecated/set- name assigned-val)
             (assert.is_same expected-vals (get-o-lo-go name)))))
-      (it "removes option value of kv-table"
+      (it* "removes option value of kv-table"
         (let [name :listchars
               assigned-val {:lead :a :trail :b :extends :c}]
           (-> (. vim.opt name) (: :remove assigned-val))

--- a/tests/spec/prerequisites_spec.fnl
+++ b/tests/spec/prerequisites_spec.fnl
@@ -1,6 +1,6 @@
-(import-macros {: describe : it} :_busted_macros)
+(import-macros {: describe* : it*} :_busted_macros)
 
-(describe :prerequisites
-  (it "vim.api is not nil"
+(describe* :prerequisites
+  (it* "vim.api is not nil"
     (assert.is_not_nil vim)
     (assert.is_not_nil vim.api)))

--- a/tests/spec/variable_spec.fnl
+++ b/tests/spec/variable_spec.fnl
@@ -1,18 +1,18 @@
-(import-macros {: describe : it} :_busted_macros)
+(import-macros {: before-each : describe* : it*} :_busted_macros)
 (import-macros {: b! : env!} :nvim-laurel.macros)
 
-(describe :b!
-  (before_each (fn []
+(describe* :b!
+  (before-each (fn []
                  (set vim.b.foo nil)
                  (set vim.b.bar nil)
                  (set vim.env.FOO nil)
                  (set vim.env.BAR nil)))
-  (it "sets environment variable in the editor session"
+  (it* "sets environment variable in the editor session"
     (env! :FOO :foo)
     (env! :$BAR :bar)
     (assert.is.same :foo vim.env.FOO)
     (assert.is.same :bar vim.env.BAR))
-  (it "sets buffer-local variable"
+  (it* "sets buffer-local variable"
     (let [buf (vim.api.nvim_get_current_buf)]
       (vim.cmd.new)
       (vim.cmd.only)


### PR DESCRIPTION
This change simplifies compiled Lua spec codes to make it much easier to find unexpected compiled results.