### PR TITLE
feat(autocmd)!: make `au!`/`autocmd!` macro interpret the symbol `*` in pattern as an alias of `["*"]`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -278,10 +278,10 @@ Create or get an augroup, or override an existing augroup.
 (augroup! :sample-augroup
   [:TextYankPost #(vim.highlight.on_yank {:timeout 450 :on_visual false})]
   (autocmd! [:InsertEnter :InsertLeave]
-      [:<buffer> :desc "call foo#bar() without any args"] vim.fn.foo#bar)
-  (autocmd! :VimEnter [:once :nested :desc "call baz#qux() with <amatch>"]
+      [:buffer :desc "call foo#bar() without any args"] vim.fn.foo#bar)
+  (autocmd! :VimEnter * [:once :nested :desc "call baz#qux() with <amatch>"]
       #(vim.fn.baz#qux $.match)))
-  (autocmd! :LspAttach
+  (autocmd! :LspAttach *
       #(au! $.group :CursorHold [:buffer $.buf] vim.lsp.buf.document_highlight))
 ```
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -251,9 +251,10 @@ Create or get an augroup, or override an existing augroup.
   use macro/function named `au!` or `autocmd!` here.
 - `name`: (string) The name of autocmd group.
 - `events`: (string|string[]) The event or events to register this autocmd.
-- `?pattern`: (bare-sequence) Patterns to match against. To set `pattern` in
-  symbol or list, set it in either `extra-opts` or `api-opts` instead. The
+- `?pattern`: (bare-sequence|`*`) Patterns to match against. To set `pattern`
+  in symbol or list, set it in either `extra-opts` or `api-opts` instead. The
   first pattern in string cannot be any of the keys used in `?extra-opts`.
+  The symbol `*` is available to imply pattern `"*"` here.
 - `?extra-opts`: (bare-sequence) Additional option:
   - `<buffer>`: Create autocmd to current buffer by itself.
   - `buffer`: (number?) Create command in the buffer of the next

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -495,7 +495,7 @@
                     ?pat)
             pattern (if (= `* pat) "*"
                         pat)]
-        ;; Note: `*` is the default pattern and redundant.
+        ;; Note: `*` is the default pattern and redundant in compiled result.
         (when-not (and (str? pattern) (= "*" pattern))
           (set extra-opts.pattern pattern)))
       (if (or ?vim-indice (str? callback) (vim-callback-format? callback))

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -448,7 +448,7 @@
       this `autocmd!` macro is within either `augroup!` or `augroup+` macro.
       Set it to `nil` to define `autocmd`s affiliated with no augroup.
   @param events string|string[] The event or events to register this autocmd.
-  @param ?pattern bare-sequence
+  @param ?pattern bare-sequence|`*` pattern(s) to match literally `autocmd-pattern`.
   @param ?extra-opts bare-sequence Addition to `api-opts` keys, `:<buffer>` is
       available to set `autocmd` to current buffer.
   @param callback string|function Set either vim Ex command, or function. Any
@@ -577,7 +577,7 @@
       this `autocmd!` macro is within either `augroup!` or `augroup+` macro.
       Set it to `nil` to define `autocmd`s affiliated with no augroup.
   @param events string|string[] The event or events to register this autocmd.
-  @param ?pattern bare-sequence
+  @param ?pattern bare-sequence|`*` pattern(s) to match literally `autocmd-pattern`.
   @param ?extra-opts bare-sequence Addition to `api-opts` keys, `:<buffer>` is
       available to set `autocmd` to current buffer.
   @param callback string|function Set either vim Ex command, or function. Any

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -469,7 +469,11 @@
           (match rest
             [cb nil nil nil] (values nil nil cb nil)
             (where [a ex-opts c ?d] (sequence? ex-opts)) (values a ex-opts c ?d)
-            [a b ?c nil] (if (or (str? a) (hidden-in-compile-time? a))
+            [a b ?c nil] (if (or (= `* a) (= [`*] a))
+                             (if (sequence? b)
+                                 (values "*" b ?c)
+                                 (values "*" nil b ?c))
+                             (or (str? a) (hidden-in-compile-time? a))
                              (values nil nil a b)
                              (contains? (tbl->keys autocmd/extra-opt-keys)
                                         (first a))
@@ -486,9 +490,12 @@
           ?pat (or extra-opts.pattern ?pattern)]
       (set extra-opts.group ?id)
       (set extra-opts.buffer ?bufnr)
-      (let [pattern (if (and (sequence? ?pat) (= 1 (length ?pat)))
-                        (first ?pat)
-                        ?pat)]
+      (let [pat (if (and (sequence? ?pat) (= 1 (length ?pat)))
+                    (first ?pat)
+                    ?pat)
+            pattern (if (or (= `* pat) (= [`*] pat))
+                        "*"
+                        pat)]
         ;; Note: `*` is the default pattern and redundant.
         (when-not (and (str? pattern) (= "*" pattern))
           (set extra-opts.pattern pattern)))

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -469,7 +469,7 @@
           (match rest
             [cb nil nil nil] (values nil nil cb nil)
             (where [a ex-opts c ?d] (sequence? ex-opts)) (values a ex-opts c ?d)
-            [a b ?c nil] (if (or (= `* a) (= [`*] a))
+            [a b ?c nil] (if (= `* a)
                              (if (sequence? b)
                                  (values "*" b ?c)
                                  (values "*" nil b ?c))
@@ -493,8 +493,7 @@
       (let [pat (if (and (sequence? ?pat) (= 1 (length ?pat)))
                     (first ?pat)
                     ?pat)
-            pattern (if (or (= `* pat) (= [`*] pat))
-                        "*"
+            pattern (if (= `* pat) "*"
                         pat)]
         ;; Note: `*` is the default pattern and redundant.
         (when-not (and (str? pattern) (= "*" pattern))

--- a/test/autocmd_spec.fnl
+++ b/test/autocmd_spec.fnl
@@ -269,6 +269,31 @@
           (assert.is_same seq-pat au.pattern))
         (let [au (get-first-autocmd {:pattern tbl-pat})]
           (assert.is_same tbl-pat au.pattern))))
+    (describe* "with the symbol `*` at `pattern` position"
+      (describe* "without `extra-opts`"
+        (it* "can create autocmd with pattern `*`."
+          (autocmd! default-augroup default-event * default-callback)
+          (assert.is_same "*" (-> (get-first-autocmd {:group default-augroup})
+                                  (. :pattern))))
+        (describe* "but with `api-opts`"
+          (it* "can create autocmd with pattern `*`."
+            (autocmd! default-augroup default-event * default-callback
+                      {:desc :foo})
+            (assert.is_same "*"
+                            (-> (get-first-autocmd {:group default-augroup})
+                                (. :pattern))))))
+      (describe* "preceding `extra-opts`"
+        (it* "can create autocmd with pattern `*`."
+          (autocmd! default-augroup default-event * [:desc :foo]
+                    default-callback)
+          (assert.is_same "*" (-> (get-first-autocmd {:group default-augroup})
+                                  (. :pattern)))))
+      (describe* "preceding both `extra-opts` and `api-opts`"
+        (it* "can create autocmd with pattern `*`."
+          (autocmd! default-augroup default-event * [:nested] default-callback
+                    {:desc :foo})
+          (let [au (get-first-autocmd {:group default-augroup-id})]
+            (assert.is_same "*" au.pattern)))))
     (describe* "detects 2 args:"
       (it* "sequence pattern and string callback"
         (autocmd! default-augroup default-event [:pat] :callback))

--- a/test/autocmd_spec.fnl
+++ b/test/autocmd_spec.fnl
@@ -87,7 +87,33 @@
                                [default-event default-callback]
                                (au! :FileType [:foo :bar] #:foobar)
                                [default-event default-callback]
-                               (au! :FileType [:foo :bar] #:foobar)))))
+                               (au! :FileType [:foo :bar] #:foobar))))
+    (describe* "including bare-sequences with the symbol `*` at `pattern` position"
+      (describe* "without `extra-opts`"
+        (it* "can create autocmd with pattern `*`."
+          (augroup! default-augroup
+            [default-event * default-callback])
+          (assert.is_same "*" (-> (get-first-autocmd {:group default-augroup})
+                                  (. :pattern))))
+        (describe* "but with `api-opts`"
+          (it* "can create autocmd with pattern `*`."
+            (augroup! default-augroup
+              [default-event * default-callback {:desc :foo}])
+            (assert.is_same "*"
+                            (-> (get-first-autocmd {:group default-augroup})
+                                (. :pattern))))))
+      (describe* "preceding `extra-opts`"
+        (it* "can create autocmd with pattern `*`."
+          (augroup! default-augroup
+            [default-event * [:desc :foo] default-callback])
+          (assert.is_same "*" (-> (get-first-autocmd {:group default-augroup})
+                                  (. :pattern)))))
+      (describe* "preceding both `extra-opts` and `api-opts`"
+        (it* "can create autocmd with pattern `*`."
+          (augroup! default-augroup
+            [default-event * [:nested] default-callback {:desc :foo}])
+          (let [au (get-first-autocmd {:group default-augroup-id})]
+            (assert.is_same "*" au.pattern))))))
   (describe* :au!/autocmd!
     (describe* "nested autocmds"
       (it* "callback arg value at `group` is `nil` when parent group is `nil`."


### PR DESCRIPTION
## TODO
- [x] Update reference
- [x] Add tests