### PR TITLE
ci(release): release without confirmation

### DIFF
--- a/.github/release-please/config.json
+++ b/.github/release-please/config.json
@@ -4,8 +4,6 @@
   "bump-patch-for-minor-pre-major": true,
   "release-search-depth": 3,
   "commit-search-depth": 50,
-  "draft": true,
-  "prerelease": true,
   "packages": {
     ".": {
       "release-type": "simple",


### PR DESCRIPTION
With the draft option on, release-please fails to find the latest release and creates a wrong PR.