### PR TITLE
feat(let!): detect `?` flag to get option value on `vim.api`

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -600,9 +600,10 @@ set `false` or `(not vim.go.foo)` respectively.
   camelCase/PascalCase. Since `:h {option}` is also case-insensitive,
   `(setlocal! :keywordPrg ":help")` for fennel still makes sense. Type `K`
   on an option name to open the vim helpfile at the tag.
-- `?flag`: (`+`|`^`|`-`|`?`) Omittable flag in symbol. Set one of `+`, `^`, `-`, or `?`
-  to append, prepend, remove, or get, option value.
-  Only available in the scopes "opt", "opt_local", or "opt_global".
+- `?flag`: (`+`|`^`|`-`|`?`) Omittable flag in symbol.
+  Set one of `+`, `^`, `-`, or `?` to append, prepend, remove, or get, option
+  value. While `?` to get value is available in all the `scope`, the other
+  flags are only available in the scopes "opt", "opt_local", or "opt_global".
 - `?val`: (boolean|number|string|table) New option value. If not provided, the
   value is supposed to be `true` (experimental). It does not work with `?id`
   argument.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -600,8 +600,8 @@ set `false` or `(not vim.go.foo)` respectively.
   camelCase/PascalCase. Since `:h {option}` is also case-insensitive,
   `(setlocal! :keywordPrg ":help")` for fennel still makes sense. Type `K`
   on an option name to open the vim helpfile at the tag.
-- `?flag`: (symbol) Omittable flag. Set one of `+`, `^`, or `-` to append,
-  prepend, or remove, value to the option.
+- `?flag`: (`+`|`^`|`-`|`?`) Omittable flag. Set one of `+`, `^`, `-`, or `?`
+  to append, prepend, remove, or get, option value.
   Only available in the scopes "opt", "opt_local", or "opt_global".
 - `?val`: (boolean|number|string|table) New option value. If not provided, the
   value is supposed to be `true` (experimental). It does not work with `?id`

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -600,7 +600,7 @@ set `false` or `(not vim.go.foo)` respectively.
   camelCase/PascalCase. Since `:h {option}` is also case-insensitive,
   `(setlocal! :keywordPrg ":help")` for fennel still makes sense. Type `K`
   on an option name to open the vim helpfile at the tag.
-- `?flag`: (`+`|`^`|`-`|`?`) Omittable flag. Set one of `+`, `^`, `-`, or `?`
+- `?flag`: (`+`|`^`|`-`|`?`) Omittable flag in symbol. Set one of `+`, `^`, `-`, or `?`
   to append, prepend, remove, or get, option value.
   Only available in the scopes "opt", "opt_local", or "opt_global".
 - `?val`: (boolean|number|string|table) New option value. If not provided, the

--- a/fnl/laurel/macros.fnl
+++ b/fnl/laurel/macros.fnl
@@ -1064,8 +1064,7 @@ For example,
                      `(tset vim ,scope ,... true))
           `(tset vim ,scope ,...))
       (let [supported-flags [`+ `- `^ `? `! `& `<]
-            (args-without-flags symbols) (extract-symbols [...]
-                                                          supported-flags)
+            (args-without-flags symbols) (extract-symbols [...] supported-flags)
             ?flag (next symbols)]
         (assert (< (length (tbl->keys symbols)) 2)
                 "only one symbol is supported at most")

--- a/fnl/laurel/macros.fnl
+++ b/fnl/laurel/macros.fnl
@@ -1146,6 +1146,12 @@ For example,
               (option/modify {:scope :local} name val ?flag)
               (where (or :go :opt_global))
               (option/modify {:scope :global} name val ?flag)
+              (:bo [name nil nil])
+              ;; Getter with "?"
+              (option/modify {:buf 0} name nil "?")
+              (:wo [name nil nil])
+              ;; Getter with "?"
+              (option/modify {:win 0} name nil "?")
               (:bo [name val nil])
               (option/modify {:buf 0} name val)
               (:wo [name val nil])

--- a/fnl/laurel/macros.fnl
+++ b/fnl/laurel/macros.fnl
@@ -1064,8 +1064,8 @@ For example,
                      `(tset vim ,scope ,... true))
           `(tset vim ,scope ,...))
       (let [supported-flags [`+ `- `^ `? `! `& `<]
-            (args-without-symbol symbols) (extract-symbols [...]
-                                                           supported-flags)
+            (args-without-flags symbols) (extract-symbols [...]
+                                                          supported-flags)
             ?flag (next symbols)]
         (assert (< (length (tbl->keys symbols)) 2)
                 "only one symbol is supported at most")
@@ -1081,17 +1081,17 @@ For example,
                 :env (values 2 `vim.fn.setenv `vim.fn.getenv))
           (max-args setter getter)
           ;; Vim Variables
-          (let [(?id name val) (case (length args-without-symbol)
-                                 3 (unpack args-without-symbol)
+          (let [(?id name val) (case (length args-without-flags)
+                                 3 (unpack args-without-flags)
                                  2 (case max-args
-                                     2 (values nil (unpack args-without-symbol))
-                                     3 (values 0 (unpack args-without-symbol)))
+                                     2 (values nil (unpack args-without-flags))
+                                     3 (values 0 (unpack args-without-flags)))
                                  1 (case max-args
-                                     2 (values nil (unpack args-without-symbol)
+                                     2 (values nil (unpack args-without-flags)
                                                (deprecate "(Partial) The format `let!` without value"
                                                           "Set `true` to set it to `true` explicitly"
                                                           :v0.8.0 true))
-                                     3 (values 0 (unpack args-without-symbol)
+                                     3 (values 0 (unpack args-without-flags)
                                                (deprecate "(Partial) The format `let!` without value"
                                                           "Set `true` to set it to `true` explicitly"
                                                           :v0.8.0 true))))
@@ -1105,13 +1105,13 @@ For example,
                   3 `(,setter ,?id ,name* ,val))))
           _
           ;; Vim Options
-          (let [[name ?val] args-without-symbol
+          (let [[name ?val] args-without-flags
                 val (if (= nil ?val ?flag)
                         (deprecate "(Partial) The format `let!` without value"
                                    "Set `true` to set it to `true` explicitly"
                                    :v0.8.0 true)
                         ?val)]
-            (case (values scope args-without-symbol)
+            (case (values scope args-without-flags)
               ;; Note: In the `case` body above, the scope for vim.opt,
               ;; vim.opt_local, and vim.opt_global max-args would be 2 or
               ;; 3 regardless of extra symbol `+`, `-`, and so on; however, in

--- a/fnl/laurel/macros.fnl
+++ b/fnl/laurel/macros.fnl
@@ -1085,7 +1085,9 @@ For example,
                                  3
                                  (case actual-arg-count
                                    3 (unpack args-without-flags)
-                                   2 (values 0 (unpack args-without-flags))
+                                   2 (if (= "?" ?flag)
+                                         (unpack args-without-flags)
+                                         (values 0 (unpack args-without-flags)))
                                    1 (values 0 (unpack args-without-flags)
                                              (deprecate "(Partial) The format `let!` without value"
                                                         "Set `true` to set it to `true` explicitly"
@@ -1108,7 +1110,14 @@ For example,
                           (name:gsub "^%$" "")
                           name)]
             (if (= "?" ?flag)
-                `(,getter ,name*)
+                (case max-args
+                  2 `(,getter ,name*)
+                  3 (do
+                      (assert (or (= :number (type ?id))
+                                  (hidden-in-compile-time? ?id))
+                              (-> "for %s, expected number, got %s: %s"
+                                  (: :format name* (type ?id) (view ?id))))
+                      `(,getter ,?id ,name*)))
                 (case max-args
                   2 `(,setter ,name* ,val)
                   3 (do

--- a/fnl/laurel/macros.fnl
+++ b/fnl/laurel/macros.fnl
@@ -1114,6 +1114,7 @@ For example,
                           (name:gsub "^%$" "")
                           name)]
             (if (= setter `vim.api.nvim_set_option_value)
+                ;; Vim Options
                 (let [opts (case (values scope args-without-flags)
                              (where (or :o :opt)) {}
                              :opt_local {:scope "local"}
@@ -1124,6 +1125,7 @@ For example,
                                            (: :format (view scope) (type scope)
                                               (view args-without-flags)))))]
                   (option/modify opts name val ?flag))
+                ;; Vim Variables
                 (let [should-use-getter? (= "?" ?flag)]
                   (case max-args
                     2 (if should-use-getter?

--- a/fnl/laurel/macros.fnl
+++ b/fnl/laurel/macros.fnl
@@ -1064,33 +1064,34 @@ For example,
                      `(tset vim ,scope ,... true))
           `(tset vim ,scope ,...))
       (let [supported-flags [`+ `- `^ `? `! `& `<]
-            (args symbols) (extract-symbols [...] supported-flags)
+            (args-without-symbol symbols) (extract-symbols [...]
+                                                           supported-flags)
             ?flag (next symbols)]
         (assert (< (length (tbl->keys symbols)) 2)
                 "only one symbol is supported at most")
         (case (case scope
-                :g (values 2 `vim.api.nvim_set_var `vim.api.nvim_set_var)
+                :g (values 2 `vim.api.nvim_set_var `vim.api.nvim_get_var)
                 :b (values 3 `vim.api.nvim_buf_set_var
-                           `vim.api.nvim_buf_set_var)
+                           `vim.api.nvim_buf_get_var)
                 :w (values 3 `vim.api.nvim_win_set_var
-                           `vim.api.nvim_win_set_var)
+                           `vim.api.nvim_win_get_var)
                 :t (values 3 `vim.api.nvim_tabpage_set_var
-                           `vim.api.nvim_tabpage_set_var)
-                :v (values 2 `vim.api.nvim_set_vvar `vim.api.nvim_set_vvar)
+                           `vim.api.nvim_tabpage_get_var)
+                :v (values 2 `vim.api.nvim_set_vvar `vim.api.nvim_get_vvar)
                 :env (values 2 `vim.fn.setenv `vim.fn.getenv))
           (max-args setter getter)
           ;; Vim Variables
-          (let [(?id name val) (case (length args)
-                                 3 (values (unpack args))
+          (let [(?id name val) (case (length args-without-symbol)
+                                 3 (unpack args-without-symbol)
                                  2 (case max-args
-                                     2 (values nil (unpack args))
-                                     3 (values 0 (unpack args)))
+                                     2 (values nil (unpack args-without-symbol))
+                                     3 (values 0 (unpack args-without-symbol)))
                                  1 (case max-args
-                                     2 (values nil (unpack args)
+                                     2 (values nil (unpack args-without-symbol)
                                                (deprecate "(Partial) The format `let!` without value"
                                                           "Set `true` to set it to `true` explicitly"
                                                           :v0.8.0 true))
-                                     3 (values 0 (unpack args)
+                                     3 (values 0 (unpack args-without-symbol)
                                                (deprecate "(Partial) The format `let!` without value"
                                                           "Set `true` to set it to `true` explicitly"
                                                           :v0.8.0 true))))
@@ -1104,13 +1105,13 @@ For example,
                   3 `(,setter ,?id ,name* ,val))))
           _
           ;; Vim Options
-          (let [[name ?val] args
+          (let [[name ?val] args-without-symbol
                 val (if (= nil ?val ?flag)
                         (deprecate "(Partial) The format `let!` without value"
                                    "Set `true` to set it to `true` explicitly"
                                    :v0.8.0 true)
                         ?val)]
-            (case (values scope args)
+            (case (values scope args-without-symbol)
               ;; Note: In the `case` body above, the scope for vim.opt,
               ;; vim.opt_local, and vim.opt_global max-args would be 2 or
               ;; 3 regardless of extra symbol `+`, `-`, and so on; however, in

--- a/fnl/laurel/macros.fnl
+++ b/fnl/laurel/macros.fnl
@@ -1001,6 +1001,7 @@ For example,
                      `(table.concat ,?val))
                  ?val)]
     (case (or ?flag ?infix-flag)
+      "?" `(vim.api.nvim_get_option_value ,name ,api-opts)
       nil
       (case (option/->?vim-value ?val)
         vim-val `(vim.api.nvim_set_option_value ,name ,vim-val ,api-opts)

--- a/fnl/laurel/macros.fnl
+++ b/fnl/laurel/macros.fnl
@@ -1018,8 +1018,8 @@ For example,
       "<" ; Sync local option to global one.
       `(vim.api.nvim_set_option_value ,name ;
                                       (vim.api.nvim_get_option_value ,name
-                                                                     {:scope :global})
-                                      {:scope :local})
+                                                                     {:scope "global"})
+                                      {:scope "local"})
       ;; "&" `(vim.cmd.set (.. ,name "&"))
       _
       (error* (.. "Invalid vim option modifier: " (view ?flag))))))
@@ -1116,8 +1116,8 @@ For example,
             (if (= setter `vim.api.nvim_set_option_value)
                 (let [opts (case (values scope args-without-flags)
                              (where (or :o :opt)) {}
-                             :opt_local {:scope :local}
-                             (where (or :go :opt_global)) {:scope :global}
+                             :opt_local {:scope "local"}
+                             (where (or :go :opt_global)) {:scope "global"}
                              :bo {:buf ?id}
                              :wo {:win ?id}
                              _ (error* (-> "Invalid scope %s in type %s with args %s to be `unpack`ed"

--- a/fnl/laurel/macros.fnl
+++ b/fnl/laurel/macros.fnl
@@ -1124,23 +1124,18 @@ For example,
                                            (: :format (view scope) (type scope)
                                               (view args-without-flags)))))]
                   (option/modify opts name val ?flag))
-                (= "?" ?flag)
                 (case max-args
-                  2 `(,getter ,name*)
+                  2 (if (= "?" ?flag)
+                        `(,getter ,name*)
+                        `(,setter ,name* ,val))
                   3 (do
                       (assert (or (= :number (type ?id))
                                   (hidden-in-compile-time? ?id))
                               (-> "for %s, expected number, got %s: %s"
                                   (: :format name* (type ?id) (view ?id))))
-                      `(,getter ,?id ,name*)))
-                (case max-args
-                  2 `(,setter ,name* ,val)
-                  3 (do
-                      (assert (or (= :number (type ?id))
-                                  (hidden-in-compile-time? ?id))
-                              (-> "for %s, expected number, got %s: %s"
-                                  (: :format name* (type ?id) (view ?id))))
-                      `(,setter ,?id ,name* ,val)))))))))
+                      (if (= "?" ?flag)
+                          `(,getter ,?id ,name*)
+                          `(,setter ,?id ,name* ,val))))))))))
 
 (λ set! [...]
   "(Deprecated in favor of `let!`)

--- a/fnl/laurel/macros.fnl
+++ b/fnl/laurel/macros.fnl
@@ -981,8 +981,8 @@ For example,
                                raw-name)
         interface (case api-opts
                     {:scope nil :buf nil :win nil} `vim.opt
-                    {:scope :local} `vim.opt_local
-                    {:scope :global} `vim.opt_global
+                    {:scope "local"} `vim.opt_local
+                    {:scope "global"} `vim.opt_global
                     {: buf :win nil} (if (= 0 buf) `vim.bo `(. vim.bo ,buf))
                     {: win :buf nil} (if (= 0 win) `vim.wo `(. vim.wo ,win))
                     _ (error* (.. "invalid api-opts: " (view api-opts))))

--- a/fnl/laurel/macros.fnl
+++ b/fnl/laurel/macros.fnl
@@ -1124,18 +1124,19 @@ For example,
                                            (: :format (view scope) (type scope)
                                               (view args-without-flags)))))]
                   (option/modify opts name val ?flag))
-                (case max-args
-                  2 (if (= "?" ?flag)
-                        `(,getter ,name*)
-                        `(,setter ,name* ,val))
-                  3 (do
-                      (assert (or (= :number (type ?id))
-                                  (hidden-in-compile-time? ?id))
-                              (-> "for %s, expected number, got %s: %s"
-                                  (: :format name* (type ?id) (view ?id))))
-                      (if (= "?" ?flag)
-                          `(,getter ,?id ,name*)
-                          `(,setter ,?id ,name* ,val))))))))))
+                (let [should-use-getter? (= "?" ?flag)]
+                  (case max-args
+                    2 (if should-use-getter?
+                          `(,getter ,name*)
+                          `(,setter ,name* ,val))
+                    3 (do
+                        (assert (or (= :number (type ?id))
+                                    (hidden-in-compile-time? ?id))
+                                (-> "for %s, expected number, got %s: %s"
+                                    (: :format name* (type ?id) (view ?id))))
+                        (if should-use-getter?
+                            `(,getter ,?id ,name*)
+                            `(,setter ,?id ,name* ,val)))))))))))
 
 (λ set! [...]
   "(Deprecated in favor of `let!`)

--- a/fnl/laurel/macros.fnl
+++ b/fnl/laurel/macros.fnl
@@ -1153,7 +1153,11 @@ For example,
               (:bo [id name val])
               (option/modify {:buf id} name val)
               (:wo [id name val])
-              (option/modify {:win id} name val)))))))
+              (option/modify {:win id} name val)
+              _
+              (error* (-> "Invalid scope %s in type %s with args %s to be `unpack`ed"
+                          (: :format (view scope) (type scope)
+                             (view args-without-flags))))))))))
 
 (λ set! [...]
   "(Deprecated in favor of `let!`)

--- a/fnl/laurel/macros.fnl
+++ b/fnl/laurel/macros.fnl
@@ -1111,7 +1111,12 @@ For example,
                 `(,getter ,name*)
                 (case max-args
                   2 `(,setter ,name* ,val)
-                  3 `(,setter ,?id ,name* ,val))))
+                  3 (do
+                      (assert (or (= :number (type ?id))
+                                  (hidden-in-compile-time? ?id))
+                              (-> "for %s, expected number, got %s: %s"
+                                  (: :format name* (type ?id) (view ?id))))
+                      `(,setter ,?id ,name* ,val)))))
           _
           ;; Vim Options
           (let [[name ?val] args-without-flags

--- a/fnl/laurel/macros.fnl
+++ b/fnl/laurel/macros.fnl
@@ -1080,20 +1080,30 @@ For example,
                 :env (values 2 `vim.fn.setenv `vim.fn.getenv))
           (max-args setter getter)
           ;; Vim Variables
-          (let [(?id name val) (case (length args-without-flags)
-                                 3 (unpack args-without-flags)
-                                 2 (case max-args
-                                     2 (values nil (unpack args-without-flags))
-                                     3 (values 0 (unpack args-without-flags)))
-                                 1 (case max-args
-                                     2 (values nil (unpack args-without-flags)
-                                               (deprecate "(Partial) The format `let!` without value"
-                                                          "Set `true` to set it to `true` explicitly"
-                                                          :v0.8.0 true))
-                                     3 (values 0 (unpack args-without-flags)
-                                               (deprecate "(Partial) The format `let!` without value"
-                                                          "Set `true` to set it to `true` explicitly"
-                                                          :v0.8.0 true))))
+          (let [actual-arg-count (length args-without-flags)
+                (?id name val) (case max-args
+                                 3
+                                 (case actual-arg-count
+                                   3 (unpack args-without-flags)
+                                   2 (values 0 (unpack args-without-flags))
+                                   1 (values 0 (unpack args-without-flags)
+                                             (deprecate "(Partial) The format `let!` without value"
+                                                        "Set `true` to set it to `true` explicitly"
+                                                        :v0.8.0 true))
+                                   _ (error* (.. "expected 1, 2, or 3 args, got "
+                                                 actual-arg-count)))
+                                 ;; For 2, `?id` should be `nil`.
+                                 2
+                                 (case actual-arg-count
+                                   2 (values nil (unpack args-without-flags))
+                                   1 (values nil (unpack args-without-flags)
+                                             (deprecate "(Partial) The format `let!` without value"
+                                                        "Set `true` to set it to `true` explicitly"
+                                                        :v0.8.0 true))
+                                   _ (error* (.. "expected 1 or 2 args, got "
+                                                 actual-arg-count)))
+                                 _
+                                 (error* (.. "expected 2 or 3, got " max-args)))
                 name* (if (and (= scope :env) (str? name))
                           (name:gsub "^%$" "")
                           name)]

--- a/fnl/laurel/macros.fnl
+++ b/fnl/laurel/macros.fnl
@@ -1153,13 +1153,13 @@ For example,
               ;; Getter with "?"
               (option/modify {:win 0} name nil "?")
               (:bo [name val nil])
-              (option/modify {:buf 0} name val)
+              (option/modify {:buf 0} name val ?flag)
               (:wo [name val nil])
-              (option/modify {:win 0} name val)
+              (option/modify {:win 0} name val ?flag)
               (:bo [id name val])
-              (option/modify {:buf id} name val)
+              (option/modify {:buf id} name val ?flag)
               (:wo [id name val])
-              (option/modify {:win id} name val)
+              (option/modify {:win id} name val ?flag)
               _
               (error* (-> "Invalid scope %s in type %s with args %s to be `unpack`ed"
                           (: :format (view scope) (type scope)

--- a/test/let!-getter.option_spec.fnl
+++ b/test/let!-getter.option_spec.fnl
@@ -1,0 +1,84 @@
+(import-macros {: describe* : it*} :test.helper.busted-macros)
+
+(import-macros {: let!} :laurel.macros)
+
+(macro get-o [name]
+  `(-> (. vim.opt ,name) (: :get)))
+
+(macro get-go [name]
+  `(. vim.go ,name))
+
+(macro get-lo [name]
+  `(-> (. vim.opt_local ,name) (: :get)))
+
+(macro get-o-lo-go [name]
+  "Get option values.
+  @param name string
+  @return any[]"
+  `[(get-o ,name) (get-lo ,name) (get-go ,name)])
+
+(local default-opt-map
+       ;; Note: The default option values are supposed to be different from
+       ;; Neovim default value.
+       {;;; buffer-local options
+        ;; boolean (bo)
+        :expandtab true
+        ;; number (bo)
+        :tabstop 1
+        ;; string (bo) x
+        :omnifunc :xyx
+        ;; sequence (bo)
+        :path "/tmp,/var,/usr"
+        ;; kv-table (bo)
+        ;; Note: None of buf-local option can be set in kv-table probably.
+        ;;:matchpairs "x:X,y:Y,z:Z"
+        ;;; window-local options
+        ;; boolean (wo)
+        :wrap true
+        ;; number (wo)
+        :foldlevel 1
+        ;; string (wo)
+        :signcolumn :yes
+        ;; sequence (wo)
+        :colorcolumn "+1,+2,+3"
+        ;; kv-table (wo)
+        :listchars "eol:x,tab:xy,space:x"
+        ;; shortmess (should be set both in string or bare-sequence)
+        :shortmess :fiw
+        ;; formatoptions (should be set both in string or bare-sequence)
+        :formatoptions :12b})
+
+(fn reset-context! []
+  "Reset test context."
+  (each [name val (pairs default-opt-map)]
+    (tset vim.opt name val)
+    (assert.is_same val (. vim.go name))
+    (assert.is_same val (. vim.o name)))
+  (vim.cmd.new)
+  (vim.cmd.only)
+  (each [name val (pairs default-opt-map)]
+    (assert.is_same val (. vim.o name))))
+
+(describe* "`let!` with a symbol `?`"
+  (before_each (fn []
+                 (reset-context!)))
+  (describe* "can return value"
+    (describe* "in the format that `vim.api` function returns"
+      (describe* "of option"
+        (it* "`:opt_local`"
+          (set vim.opt_local.expandtab false)
+          (assert.is_false (let! :opt_local :expandtab ?))
+          (set vim.opt_local.expandtab true)
+          (assert.is_true (let! :opt_local :expandtab ?)))
+        (describe* "`:bo`"
+          (it* "in boolean"
+            (set vim.bo.expandtab false)
+            (assert.is_false (let! :bo :expandtab ?))
+            (set vim.bo.expandtab true)
+            (assert.is_true (let! :bo :expandtab ?))))
+        (describe* "`:wo`"
+          (it* "in boolean"
+            (set vim.wo.wrap false)
+            (assert.is_false (let! :wo :wrap ?))
+            (set vim.wo.wrap true)
+            (assert.is_true (let! :wo :wrap ?))))))))

--- a/test/let!-getter.option_spec.fnl
+++ b/test/let!-getter.option_spec.fnl
@@ -75,10 +75,26 @@
             (set vim.bo.expandtab false)
             (assert.is_false (let! :bo :expandtab ?))
             (set vim.bo.expandtab true)
-            (assert.is_true (let! :bo :expandtab ?))))
+            (assert.is_true (let! :bo :expandtab ?)))
+          (describe* "with index"
+            (it* "in boolean"
+              (let [buf (vim.api.nvim_get_current_buf)]
+                (vim.cmd.new)
+                (tset vim.bo buf :expandtab false)
+                (assert.is_false (let! :bo buf :expandtab ?))
+                (tset vim.bo buf :expandtab true)
+                (assert.is_true (let! :bo buf :expandtab ?))))))
         (describe* "`:wo`"
           (it* "in boolean"
             (set vim.wo.wrap false)
             (assert.is_false (let! :wo :wrap ?))
             (set vim.wo.wrap true)
-            (assert.is_true (let! :wo :wrap ?))))))))
+            (assert.is_true (let! :wo :wrap ?)))
+          (describe* "with index"
+            (it* "in boolean"
+              (let [win (vim.api.nvim_get_current_win)]
+                (vim.cmd.new)
+                (tset vim.wo win :wrap false)
+                (assert.is_false (let! :wo win :wrap ?))
+                (tset vim.wo win :wrap true)
+                (assert.is_true (let! :wo win :wrap ?))))))))))

--- a/test/let!-getter.variable_spec.fnl
+++ b/test/let!-getter.variable_spec.fnl
@@ -1,0 +1,28 @@
+(import-macros {: describe* : it*} :test.helper.busted-macros)
+
+(import-macros {: let!} :laurel.macros)
+
+;; (describe* "`let!` with a symbol `?`"
+;;   (describe* "can return value"
+;;     (describe* "in the format that `vim.api` function returns"
+;;       (describe* "of option"
+;;         (it* "`o`"
+;;           (set vim.o.tabstop 1)
+;;           (assert.equals 1 (let! :o :tabstop ?)))))))
+
+(describe* "`let!` with a symbol `?`"
+  (describe* "can return value"
+    (describe* "in the format that `vim.api` function returns"
+      (describe* "of variable"
+        (describe* "with no scope option available"
+          (it* "`:g`"
+            (set vim.g.foo 1)
+            (assert.equals 1 (let! :g :foo ?))
+            (set vim.g.foo 2)
+            (assert.equals 2 (let! :g :foo ?)))
+          (it* "`:env`"
+            ;; NOTE: vim.env, or os.getenv, returns value in string.
+            (set vim.env.foo 1)
+            (assert.equals "1" (let! :env :foo ?))
+            (set vim.env.foo 2)
+            (assert.equals "2" (let! :env :foo ?))))))))

--- a/test/let!-getter.variable_spec.fnl
+++ b/test/let!-getter.variable_spec.fnl
@@ -15,6 +15,8 @@
     (describe* "in the format that `vim.api` function returns"
       (describe* "of variable"
         (describe* "with no scope option available"
+          (it* "`:v`"
+            (assert.equals vim.v.version (let! :v :version ?)))
           (it* "`:g`"
             (set vim.g.foo 1)
             (assert.equals 1 (let! :g :foo ?))
@@ -25,4 +27,33 @@
             (set vim.env.foo 1)
             (assert.equals "1" (let! :env :foo ?))
             (set vim.env.foo 2)
-            (assert.equals "2" (let! :env :foo ?))))))))
+            (assert.equals "2" (let! :env :foo ?))))
+        (describe* "without scope index"
+          (it* "`:b`"
+            (set vim.b.foo 1)
+            (assert.equals 1 (let! :b :foo ?))
+            (set vim.b.foo 2)
+            (assert.equals 2 (let! :b :foo ?)))
+          (it* "`:w`"
+            (set vim.w.foo 1)
+            (assert.equals 1 (let! :w :foo ?))
+            (set vim.w.foo 2)
+            (assert.equals 2 (let! :w :foo ?)))
+          (it* "`:t`"
+            (set vim.t.foo 1)
+            (assert.equals 1 (let! :t :foo ?))
+            (set vim.t.foo 2)
+            (assert.equals 2 (let! :t :foo ?))))
+        (describe* "with scope index"
+          (it* "`:b`"
+            (let [idx (vim.api.nvim_get_current_buf)]
+              (tset vim.b idx :foo 1)
+              (assert.equals 1 (let! :b idx :foo ?))
+              (tset vim.b idx :foo 2)
+              (assert.equals 2 (let! :b idx :foo ?))))
+          (it* "`:w`"
+            (let [idx (vim.api.nvim_get_current_win)]
+              (tset vim.w idx :foo 1)
+              (assert.equals 1 (let! :w idx :foo ?))
+              (tset vim.w idx :foo 2)
+              (assert.equals 2 (let! :w idx :foo ?)))))))))


### PR DESCRIPTION
## TODO
- [x] Implement getter with scope-index value for `:b`, `:w`, `:t`
	- [x] ~Drop `true` supplement for `let!`, i.e., after v0.8.0 is released.~ <- turned out compatible.
- [x] Implement getter with scope-index value for `:bo`, `:wo`
- [x] Implement getter for `:opt`, `:opt_local`, ...
- [x] Add specs