### PR TITLE
refactor: validate `extra-opts` value types

### DIFF
--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -243,7 +243,7 @@
                  :format (table.concat valid-types "/") val-type))))
   val)
 
-(lambda seq->kv-table [xs option-types]
+(lambda extra-opts/seq->kv-table [xs option-types]
   "Convert `xs` into a kv-table as follows:
   - The values for `x` listed in `?option-types` are set to `true`.
   - The values for the rest of `x`s are set to the next value in `xs`.
@@ -466,7 +466,7 @@
                          (view rest))))
           extra-opts (if (nil? ?extra-opts) {}
                          (-> ?extra-opts
-                             (seq->kv-table autocmd/extra-opt-keys)))
+                             (extra-opts/seq->kv-table autocmd/extra-opt-keys)))
           ?bufnr (if extra-opts.<buffer> 0 extra-opts.buffer)
           ?pat (or extra-opts.pattern ?pattern)]
       (set extra-opts.group ?id)
@@ -625,7 +625,7 @@
               ?extra-opts (when ?seq-extra-opts
                             (-> ?seq-extra-opts
                                 ;;(supplement-extra-opts! keymap/extra-opt-keys)
-                                (seq->kv-table keymap/extra-opt-keys)))
+                                (extra-opts/seq->kv-table keymap/extra-opt-keys)))
               [extra-opts lhs raw-rhs ?api-opts] (if-not ?extra-opts
                                                    [{} a1 a2 ?a3]
                                                    (sequence? a1)
@@ -1138,7 +1138,8 @@
                             (sequence? a2) a2)
         (extra-opts name command ?api-opts) ;
         (case (when ?seq-extra-opts
-                (seq->kv-table ?seq-extra-opts command/extra-opt-keys))
+                (extra-opts/seq->kv-table ?seq-extra-opts
+                                          command/extra-opt-keys))
           nil (values {} a1 a2 ?a3)
           extra-opts (if (sequence? a1)
                          (values extra-opts a2 ?a3 ?a4)

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -232,7 +232,8 @@
                                               (+ 2 (select "#" ...)))))))
 
 (lambda validate-type [val valid-types]
-  "Validate the type of `val` is one of `valid-types`.
+  "Validate the type of `val` is one of `valid-types`. When `val` is symbol or
+  list, it's ignored.
   @param val any
   @param valid-types string|string[]
   @return any `val` as is"

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -137,6 +137,20 @@
     (fcollect [i first last]
       (. xs i))))
 
+(fn tbl->keys [tbl]
+  "Return keys of `tbl`.
+  @param tbl table
+  @return sequence"
+  (icollect [k _ (pairs tbl)]
+    k))
+
+;; (fn tbl->values [tbl]
+;;   "Return values of `tbl`.
+;;   @param tbl table
+;;   @return sequence"
+;;   (icollect [_ v (pairs tbl)]
+;;     v))
+
 (fn tbl/copy [from ?to]
   "Return a shallow copy of table `from`.
   @param from table

--- a/fnl/nvim-laurel/macros.fnl
+++ b/fnl/nvim-laurel/macros.fnl
@@ -264,25 +264,6 @@
       (++ i))
     kv-table))
 
-(lambda seq->trues [xs ?nexts]
-  "Convert `xs` into a kv-table as follows:
-  - The values for `x` listed in `?nexts` are set to the next value in `xs`.
-  - The values for the rest of `x`s are set to `true`.
-  @param xs sequence
-  @param ?nexts string[]
-  @return kv-table"
-  (let [kv-table {}
-        max (length xs)
-        nexts (or ?nexts [])]
-    (var i 1)
-    (while (<= i max)
-      (let [x (. xs i)]
-        (if (contains? nexts x)
-            (tset kv-table x (. xs (++ i)))
-            (tset kv-table x true)))
-      (++ i))
-    kv-table))
-
 (lambda merge-api-opts [?extra-opts ?api-opts]
   "Merge `?api-opts` into `?extra-opts` safely.
   @param ?extra-opts kv-table|nil


### PR DESCRIPTION
The validation skips values in a symbol or list.