### PR TITLE
fix(highlight): remove `link` attribute restriction at compile time

### DIFF
--- a/fnl/laurel/macros.fnl
+++ b/fnl/laurel/macros.fnl
@@ -1217,30 +1217,22 @@
                                   ;; `default/merge-opts!` could not work
                                   ;; expectedly.
                                   api-opts)]
-    (if (?. api-opts* :link)
-        (each [k _ (pairs api-opts*)]
-          (assert-compile (= k :link)
-                          (.. "`link` key excludes any other options: " k)
-                          api-opts*))
-        (do
-          (when (nil? api-opts*.ctermfg)
-            (set api-opts*.ctermfg (?. api-opts* :cterm :fg))
-            (when api-opts*.cterm
-              (set api-opts*.cterm.fg nil)))
-          (when (nil? api-opts*.ctermbg)
-            (set api-opts*.ctermbg (?. api-opts* :cterm :bg))
-            (when api-opts*.cterm
-              (set api-opts*.cterm.bg nil)))
-          (assert-compile (or (cterm-color? api-opts*.ctermfg)
-                              (hidden-in-compile-time? api-opts*.ctermfg))
-                          (.. "ctermfg expects 256 color, got "
-                              (view api-opts*.ctermfg))
-                          api-opts*)
-          (assert-compile (or (cterm-color? api-opts*.ctermbg)
-                              (hidden-in-compile-time? api-opts*.ctermbg))
-                          (.. "ctermbg expects 256 color, got "
-                              (view api-opts*.ctermbg))
-                          api-opts*)))
+    (when (nil? api-opts*.ctermfg)
+      (set api-opts*.ctermfg (?. api-opts* :cterm :fg))
+      (when api-opts*.cterm
+        (set api-opts*.cterm.fg nil)))
+    (when (nil? api-opts*.ctermbg)
+      (set api-opts*.ctermbg (?. api-opts* :cterm :bg))
+      (when api-opts*.cterm
+        (set api-opts*.cterm.bg nil)))
+    (assert-compile (or (cterm-color? api-opts*.ctermfg)
+                        (hidden-in-compile-time? api-opts*.ctermfg))
+                    (.. "ctermfg expects 256 color, got "
+                        (view api-opts*.ctermfg)) api-opts*)
+    (assert-compile (or (cterm-color? api-opts*.ctermbg)
+                        (hidden-in-compile-time? api-opts*.ctermbg))
+                    (.. "ctermbg expects 256 color, got "
+                        (view api-opts*.ctermbg)) api-opts*)
     `(vim.api.nvim_set_hl ,(or ?ns-id 0) ,name ,api-opts*)))
 
 ;; Deprecated ///1

--- a/test/highlight_spec.fnl
+++ b/test/highlight_spec.fnl
@@ -74,6 +74,12 @@
     (highlight! :Bar {:link :Foo})
     (assert.is_same {:foreground 0 :background 255 :bold true}
                     (get-hl-of-256-color :Bar)))
+  (it* "can link to another hl-group with other attributes, but discard the attributes other than those from link"
+    (highlight! :Foo {:ctermfg 0 :ctermbg 255 :bold true})
+    (highlight! :Bar {:link :Foo :italic true :fg :Blue :ctermbg 1})
+    (assert.is_same {:foreground 0 :background 255 :bold true}
+                    (get-hl-of-256-color :Bar))
+    (assert.is_same {:bold true} (get-hl-of-rgb-color :Bar)))
   (describe* "with its value in bare-kv-table"
     (it* "can set fg/bg in cterm table instead of ctermfg/ctermbg"
       (highlight! :FooBar {:cterm {:fg 0 :bg 255 :bold true}})


### PR DESCRIPTION
As described in the [spec](https://github.com/aileot/nvim-laurel/commit/fe358f1fd764d21a588608f665a06f74275cbc92), `link` is available with other attributes, though the others do not take effect with `link` in the current stable version of nvim v0.10.0.