### PR TITLE
feat(extra-opts): allow description without `:desc` key

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -989,11 +989,13 @@ call feedkeys('foo<CR>', 'ni')
 
 ```lua
 vim.api.nvim_feedkeys(
-  vim.api.nvim_replace_termcodes("foo<CR>", true, true, true)("ni"),
+  vim.api.nvim_replace_termcodes("foo<CR>", true, true, true),
+  "ni",
   false
 )
 vim.api.nvim_feedkeys(
-  vim.api.nvim_replace_termcodes("foo<lt>CR>", true, true, true)("ni"),
+  vim.api.nvim_replace_termcodes("foo<lt>CR>", true, true, true),
+  "ni",
   false
 )
 ```

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -140,6 +140,13 @@ the following features:
 - It is intended as shorthand; for complicated usage, use `api-opts` instead
   or use them together.
 - It could accept some additional keys which are unavailable in `api-opts`.
+- _(since v0.7.4)_
+  The `:desc` key can be omitted if the description is written in the first
+  argument of `extra-opts` and does not match against any other keys of
+  `extra-opts`.
+
+  (Note that [`autocmd!`](#autocmd-1) additionally has a minor exception.
+  Please refer to the inline link for details.)
 
 ### Reserved Symbol
 
@@ -259,6 +266,13 @@ Create or get an augroup, or override an existing augroup.
   - `buffer`: (number?) Create command in the buffer of the next
     value. Without 0 or no following number, create autocmd to current buffer
     by itself.
+
+  Note: The `:desc` key can be omitted if the description is written in the
+  first argument of `extra-opts` and does not match against any other keys of
+  `extra-opts`.
+  However, unlike other macros, if `?pattern` is also omitted, `autocmd!`
+  additionally requires at least one other `extra-opts` key to omit `:desc`.
+
 - `callback`: (string|function) Set either callback function or Ex command. A
   callback is interpreted as Lua function by default. To set Ex command, you
   have three options:
@@ -391,6 +405,10 @@ Map `lhs` to `rhs` in `modes`, non-recursively by default.
   - `wait`: Disable `nowait` _in extra-opts;_ will NOT disable `nowait`
     _in api-opts_. Useful in wrapper macro which set `nowait` with
     `&default-opts`.
+
+  Note: The `:desc` key can be omitted if the description is written in the
+  first argument of `extra-opts` and does not match against any other keys of
+  `extra-opts`.
 
 - `lhs`: (string) Left-hand-side of the mapping.
 - `rhs`: (string|function) Right-hand-side of the mapping. Set either callback
@@ -938,6 +956,10 @@ Create a user command.
 
   - `buffer`: Create command in the buffer of the next value. Without 0 or no
     following number, create autocmd to current buffer by itself.
+
+  Note: The `:desc` key can be omitted if the description is written in the
+  first argument of `extra-opts` and does not match against any other keys of
+  `extra-opts`.
 
 - `name`: (string) Name of the new user command. It must begin with an
   uppercase letter.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -148,8 +148,7 @@ macros to extend their functionalities.
 
 #### `&vim`
 
-_(Since v0.5.3)_
-
+_(Since v0.5.3)_\
 A reserved symbol to set Vim script callback in symbol or list.  
 Basically, symbol and list are interpreted as Lua callback function in the
 lists of nvim-laurel macros.
@@ -164,8 +163,7 @@ List of macros in which `&vim` makes sense:
 
 #### `&default-opts`
 
-_(Since v0.6.1)_
-
+_(Since v0.6.1)_\
 A reserved symbol to set default values of `api-opts` fields.  
 It indicates that the bare `kv-table` next to the symbol `&default-opts`
 contains default values for `api-opts`, but it also interprets the additional

--- a/fnl/laurel/macros.fnl
+++ b/fnl/laurel/macros.fnl
@@ -515,8 +515,7 @@ instead to set a Vimscript function.
                                  (values "*" nil b ?c))
                              (or (str? a) (hidden-in-compile-time? a))
                              (values nil nil a b)
-                             (contains? (tbl->keys autocmd/extra-opt-keys)
-                                        (first a))
+                             (. autocmd/extra-opt-keys (first a))
                              (values nil a b ?c)
                              (values a nil b ?c))
             _ (error* (: "unexpected args:\n?id: %s\nevents: %s\nrest: %s"

--- a/fnl/laurel/macros.fnl
+++ b/fnl/laurel/macros.fnl
@@ -286,6 +286,17 @@ list, it's ignored.
       (++ i))
     kv-table))
 
+(lambda extra-opts/supplement-desc-key! [extra-opts extra-opt-valid-keys]
+   ;; TODO: Add this feature after a version update where `autocmd!` should
+   ;; demand pattern or buffer just before extra-opts.
+   "Insert missing `desc` key in `extra-opts` sequence.
+   @param extra-opts sequence
+   @param extra-opt-valid-keys string[]
+   @return sequence"
+   (when-not (contains? extra-opt-valid-keys (first extra-opts))
+     (table.insert extra-opts 1 :desc)
+     extra-opts))
+
 (λ merge-api-opts [?extra-opts ?api-opts]
   "Merge `?api-opts` into `?extra-opts` safely.
 @param ?extra-opts kv-table|nil

--- a/fnl/laurel/macros.fnl
+++ b/fnl/laurel/macros.fnl
@@ -250,6 +250,16 @@ list, it's ignored.
                  :format (table.concat valid-types "/") val-type))))
   val)
 
+(λ extra-opts/supplement-desc-key! [extra-opts extra-opt-valid-keys]
+  "Insert missing `desc` key in `extra-opts` sequence.
+@param extra-opts sequence
+@param extra-opt-valid-keys string[]
+@return sequence"
+  (if (. extra-opt-valid-keys (first extra-opts)) extra-opts
+      (do
+        (table.insert extra-opts 1 :desc)
+        extra-opts)))
+
 (λ extra-opts/seq->kv-table [xs valid-option-types]
   "Convert `xs` into a kv-table as follows:
 
@@ -263,13 +273,14 @@ list, it's ignored.
   @return kv-table"
   (assert (sequence? xs) (.. "expected sequence, got " (type xs)))
   (let [kv-table {}
-        max (length xs)]
+        new-xs (extra-opts/supplement-desc-key! xs valid-option-types)
+        max (length new-xs)]
     (var i 1)
     (while (<= i max)
-      (let [key (. xs i)
+      (let [key (. new-xs i)
             val (case (. valid-option-types key)
                   :boolean true
-                  valid-types (let [next-val (. xs (inc i))]
+                  valid-types (let [next-val (. new-xs (inc i))]
                                 (if (or (. valid-option-types next-val)
                                         (<= max i))
                                     (case valid-types
@@ -285,17 +296,6 @@ list, it's ignored.
         (tset kv-table key val))
       (++ i))
     kv-table))
-
-(lambda extra-opts/supplement-desc-key! [extra-opts extra-opt-valid-keys]
-   ;; TODO: Add this feature after a version update where `autocmd!` should
-   ;; demand pattern or buffer just before extra-opts.
-   "Insert missing `desc` key in `extra-opts` sequence.
-   @param extra-opts sequence
-   @param extra-opt-valid-keys string[]
-   @return sequence"
-   (when-not (contains? extra-opt-valid-keys (first extra-opts))
-     (table.insert extra-opts 1 :desc)
-     extra-opts))
 
 (λ merge-api-opts [?extra-opts ?api-opts]
   "Merge `?api-opts` into `?extra-opts` safely.

--- a/fnl/laurel/macros.fnl
+++ b/fnl/laurel/macros.fnl
@@ -115,12 +115,12 @@
   (assert-seq xs)
   (. xs 1))
 
-;; (lambda second [xs]
-;;   "Return the second value in `xs`.
-;;   @param xs sequence|list
-;;   @return any"
-;;   (assert-seq xs)
-;;   (. xs 2))
+(λ second [xs]
+  "Return the second value in `xs`.
+@param xs sequence|list
+@return any"
+  (assert-seq xs)
+  (. xs 2))
 
 ;; (fn last [xs]
 ;;   "Return the last value in `xs`.
@@ -515,7 +515,8 @@ instead to set a Vimscript function.
                                  (values "*" nil b ?c))
                              (or (str? a) (hidden-in-compile-time? a))
                              (values nil nil a b)
-                             (. autocmd/extra-opt-keys (first a))
+                             (or (. autocmd/extra-opt-keys (first a))
+                                 (. autocmd/extra-opt-keys (second a)))
                              (values nil a b ?c)
                              (values a nil b ?c))
             _ (error* (: "unexpected args:\n?id: %s\nevents: %s\nrest: %s"

--- a/test/autocmd_spec.fnl
+++ b/test/autocmd_spec.fnl
@@ -31,7 +31,7 @@
     (values v true)))
 
 (local get-autocmds vim.api.nvim_get_autocmds)
-(local del-autocmd vim.api.nvim_del_autocmd)
+(local del-autocmd! vim.api.nvim_del_autocmd)
 (local exec-autocmds vim.api.nvim_exec_autocmds)
 (local del-augroup-by-id vim.api.nvim_del_augroup_by_id)
 (local del-augroup-by-name vim.api.nvim_del_augroup_by_name)
@@ -79,8 +79,8 @@
                  (let [aus (get-autocmds {})]
                    (assert.is_nil (next aus)))))
   (after-each (fn []
-                (pcall del-autocmd au-id1)
-                (pcall del-autocmd au-id2)))
+                (pcall del-autocmd! au-id1)
+                (pcall del-autocmd! au-id2)))
   (describe* :augroup!
     (it* "returns augroup id without autocmds insides"
       (let [id (augroup! default-augroup)]

--- a/test/autocmd_spec.fnl
+++ b/test/autocmd_spec.fnl
@@ -45,6 +45,14 @@
 (local <default>-command :<default>-command)
 (local <default>-str-callback #:<default>-str-callback)
 
+(fn clear-any-autocmds! []
+  ;; Clear all the badly defined autocmds apart from any group.
+  (vim.api.nvim_clear_autocmds {})
+  (let [builtin-autocmds (vim.api.nvim_get_autocmds {})]
+    (each [_ {: group} (ipairs builtin-autocmds)]
+      ;; NOTE: autocmd id could be nil.
+      (vim.api.nvim_clear_autocmds {: group}))))
+
 (λ get-first-autocmd [?opts]
   (. (get-autocmds ?opts) 1))
 
@@ -62,12 +70,7 @@
 ;; nvim nightly v0.10; use `vim.api.nvim_exec_autocmds` instead.
 (describe* :autocmd
   (setup* (fn []
-            ;; Clear all the badly defined autocmds apart from any group.
-            (vim.api.nvim_clear_autocmds {})
-            (let [builtin-autocmds (vim.api.nvim_get_autocmds {})]
-              (each [_ {: group} (ipairs builtin-autocmds)]
-                ;; NOTE: autocmd id could be nil.
-                (vim.api.nvim_clear_autocmds {: group})))
+            (clear-any-autocmds!)
             (vim.cmd "function! g:Test() abort\nendfunction")))
   (teardown* (fn []
                (vim.cmd "delfunction g:Test")))

--- a/test/autocmd_spec.fnl
+++ b/test/autocmd_spec.fnl
@@ -328,6 +328,76 @@
                     {:desc :foo})
           (let [au (get-first-autocmd {:group default-augroup-id})]
             (assert.is_same "*" au.pattern)))))
+    (describe* "`:desc` key as the first `extra-opts` value can be omittable"
+      (it* "but interpreting as a pattern instead if neither pattern nor buffer is set for the autocmd"
+        (let [id (autocmd! default-augroup default-event ["foo"]
+                           default-callback)]
+          (assert.is_not_same :foo
+                              (get-first-autocmd-desc {:group default-augroup-id}))
+          (assert.is_same :foo (-> (get-first-autocmd {:group default-augroup-id})
+                                   (. :pattern)))
+          (del-autocmd! id))
+        (let [id (autocmd! default-augroup default-event ["bar"]
+                           default-callback {:once true})]
+          (assert.is_not_same :bar
+                              (get-first-autocmd-desc {:group default-augroup-id}))
+          (assert.is_same :bar (-> (get-first-autocmd {:group default-augroup-id})
+                                   (. :pattern)))
+          (del-autocmd! id)))
+      (it* "when any other keys constructs `extra-opts`."
+        (let [id (autocmd! default-augroup default-event ["bar" :nested]
+                           default-callback)]
+          (assert.is_same :bar
+                          (get-first-autocmd-desc {:group default-augroup-id}))
+          (del-autocmd! id)))
+      (it* "if pattern is `*`"
+        (let [id (autocmd! default-augroup default-event * ["foo"]
+                           default-callback)]
+          (assert.is_same :foo
+                          (get-first-autocmd-desc {:group default-augroup-id}))
+          (del-autocmd! id))
+        (let [id (autocmd! default-augroup default-event * ["bar" :nested]
+                           default-callback)]
+          (assert.is_same :bar
+                          (get-first-autocmd-desc {:group default-augroup-id}))
+          (del-autocmd! id))
+        (let [id (autocmd! default-augroup default-event * ["baz"]
+                           default-callback {:once true})]
+          (assert.is_same :baz
+                          (get-first-autocmd-desc {:group default-augroup-id}))
+          (del-autocmd! id)))
+      (it* "if pattern is set in strings"
+        (let [id (autocmd! default-augroup default-event [:foobar] ["foo"]
+                           default-callback)]
+          (assert.is_same :foo
+                          (get-first-autocmd-desc {:group default-augroup-id}))
+          (del-autocmd! id))
+        (let [id (autocmd! default-augroup default-event [:foobar]
+                           ["bar" :nested] default-callback)]
+          (assert.is_same :bar
+                          (get-first-autocmd-desc {:group default-augroup-id}))
+          (del-autocmd! id))
+        (let [id (autocmd! default-augroup default-event [:foobar] ["baz"]
+                           default-callback {:once true})]
+          (assert.is_same :baz
+                          (get-first-autocmd-desc {:group default-augroup-id}))
+          (del-autocmd! id)))
+      (it* "if pattern is set in `extra-opts`"
+        (let [id (autocmd! default-augroup default-event
+                           ["foo" :pattern :foobar] default-callback)]
+          (assert.is_same :foo
+                          (get-first-autocmd-desc {:group default-augroup-id}))
+          (del-autocmd! id))
+        (let [id (autocmd! default-augroup default-event ["bar" :nested]
+                           default-callback {:pattern :foobar})]
+          (assert.is_same :bar
+                          (get-first-autocmd-desc {:group default-augroup-id}))
+          (del-autocmd! id))
+        (let [id (autocmd! default-augroup default-event ["baz"]
+                           default-callback {:once true :pattern :foobar})]
+          (assert.is_not_same :baz
+                              (get-first-autocmd-desc {:group default-augroup-id}))
+          (del-autocmd! id))))
     (describe* "detects 2 args:"
       (it* "with `:buffer` key and string callback"
         (autocmd! default-augroup default-event [:buffer :desc :foo] :callback)

--- a/test/autocmd_spec.fnl
+++ b/test/autocmd_spec.fnl
@@ -48,6 +48,10 @@
 (λ get-first-autocmd [?opts]
   (. (get-autocmds ?opts) 1))
 
+(λ get-first-autocmd-desc [?opts]
+  (-> (get-first-autocmd ?opts) ;
+      (. :desc)))
+
 (var default-augroup-id nil)
 (var another-augroup-name nil)
 

--- a/test/autocmd_spec.fnl
+++ b/test/autocmd_spec.fnl
@@ -326,6 +326,9 @@
           (let [au (get-first-autocmd {:group default-augroup-id})]
             (assert.is_same "*" au.pattern)))))
     (describe* "detects 2 args:"
+      (it* "with `:buffer` key and string callback"
+        (autocmd! default-augroup default-event [:buffer :desc :foo] :callback)
+        (assert.is_same :foo (get-first-autocmd-desc {:buffer 0})))
       (it* "sequence pattern and string callback"
         (autocmd! default-augroup default-event [:pat] :callback))
       (it* "sequence pattern and function callback"

--- a/test/command_spec.fnl
+++ b/test/command_spec.fnl
@@ -84,7 +84,23 @@ Read `Parameters.opts.desc` of `:h nvim_create_user_command()`"
       (let [default-count 0]
         (assert.is_same (tostring default-count)
                         (-> (get-command :Foo)
-                            (. :count))))))
+                            (. :count)))))
+    (describe* "`:desc` key as the first `extra-opts` value can be omittable"
+      (it* "if `extra-opts` precedes `lhs`."
+        (command! :Foo ["foo"] default-callback)
+        (assert.is_same :foo (get-command-definition :Foo))
+        ;; NOTE: "bar" is reserved by vim.api.nvim_create_user_command.
+        (command! :Foo ["baz" :preview #nil] default-callback)
+        (assert.is_same :baz (get-command-definition :Foo))
+        (command! :Foo ["qux"] default-callback {:bang true})
+        (assert.is_same :qux (get-command-definition :Foo)))
+      (it* "if `lhs` precedes `extra-opts`."
+        (command! ["foo"] :Foo default-callback)
+        (assert.is_same :foo (get-command-definition :Foo))
+        (command! ["baz" :preview #nil] :Foo default-callback)
+        (assert.is_same :baz (get-command-definition :Foo))
+        (command! :Foo ["qux"] default-callback {:bang true})
+        (assert.is_same :qux (get-command-definition :Foo)))))
   (describe* :api-opts
     (it* "gives priority api-opts over extra-opts"
       (command! :Foo [:bar :bang] :FooBar)

--- a/test/keymap_spec.fnl
+++ b/test/keymap_spec.fnl
@@ -53,6 +53,9 @@
 (λ get-callback [mode lhs]
   (?. (get-mapargs mode lhs) :callback))
 
+(λ get-map-desc [mode lhs]
+  (?. (get-mapargs mode lhs) :desc))
+
 (λ buf-get-mapargs [bufnr mode lhs]
   (let [mappings (vim.api.nvim_buf_get_keymap bufnr mode)]
     (accumulate [rhs nil _ m (ipairs mappings) &until rhs]

--- a/test/keymap_spec.fnl
+++ b/test/keymap_spec.fnl
@@ -185,6 +185,21 @@
           (map! :n [:wait] :lhs :rhs {:nowait true})
           (let [{: nowait} (get-mapargs :n :lhs)]
             (assert.is_same 1 nowait)))))
+    (describe* "`:desc` key as the first `extra-opts` value can be omittable"
+      (it* "if `extra-opts` precedes `lhs`."
+        (map! :n :lhs ["foo"] :rhs)
+        (assert.is_same :foo (get-map-desc :n :lhs))
+        (map! :n :lhs ["bar" :nowait] :rhs)
+        (assert.is_same :bar (get-map-desc :n :lhs))
+        (map! :n :lhs ["baz"] :rhs {:nowait true})
+        (assert.is_same :baz (get-map-desc :n :lhs)))
+      (it* "if `lhs` precedes `extra-opts`."
+        (map! :n ["foo"] :lhs :rhs)
+        (assert.is_same :foo (get-map-desc :n :lhs))
+        (map! :n ["bar" :nowait] :lhs :rhs)
+        (assert.is_same :bar (get-map-desc :n :lhs))
+        (map! :n :lhs ["baz"] :rhs {:nowait true})
+        (assert.is_same :baz (get-map-desc :n :lhs))))
     (describe* :<Cmd>pattern
       (it* "symbol will be set to 'command'"
         (map! :n :lhs <default>-command)


### PR DESCRIPTION
Supplement `:desc` in `extra-opts` when the first string does not belong to any valid keys of `extra-opts`.

- [x] Add tests
- [x] Update reference.
- [x] Note that `autocmd!` macro has exceptional rules unfortunately.